### PR TITLE
Fixed rotateLabels option for multiBarCharts

### DIFF
--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -222,10 +222,10 @@ nv.models.multiBarChart = function() {
 
       if(rotateLabels)
         xTicks
-            .selectAll('text')
-            .attr('transform', function(d,i,j) { return 'rotate('+rotateLabels+' 0,0)' })
-            .attr('text-transform', rotateLabels > 0 ? 'start' : 'end');
-
+          .selectAll('text')
+          .attr('transform', 'rotate(' + rotateLabels + ' 0,0)')
+          .attr('text-anchor', rotateLabels > 0 ? 'start' : 'end');
+      
       g.select('.nv-x.nv-axis').selectAll('g.nv-axisMaxMin text')
           .style('opacity', 1);
 


### PR DESCRIPTION
Replaced 'text-transform' with correct attribute 'text-anchor' to set
rotation center of labels.
