### PR TITLE
Adding d3.event to scatter event listeners

### DIFF
--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -1,4 +1,3 @@
-
 nv.models.lineWithFocusChart = function() {
 
   //============================================================
@@ -511,6 +510,12 @@ nv.models.lineWithFocusChart = function() {
     if (!arguments.length) return showLegend;
     showLegend = _;
     return chart;
+  };
+  
+  chart.brushExtent = function(_) {
+    if (!arguments.length) return brushExtent;
+	  brushExtent = _;
+	  return chart;
   };
 
   chart.tooltips = function(_) {

--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -514,8 +514,8 @@ nv.models.lineWithFocusChart = function() {
   
   chart.brushExtent = function(_) {
     if (!arguments.length) return brushExtent;
-	  brushExtent = _;
-	  return chart;
+    brushExtent = _;
+    return chart;
   };
 
   chart.tooltips = function(_) {

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -306,7 +306,7 @@ nv.models.scatter = function() {
                   pos: [x(getX(point, i)) + margin.left, y(getY(point, i)) + margin.top],
                   seriesIndex: d.series,
                   pointIndex: i,
-                  d3.event
+                  e: d3.event
                 });
               })
               .on('mouseout', function(d,i) {

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -1,4 +1,3 @@
-
 nv.models.scatter = function() {
 
   //============================================================
@@ -231,7 +230,8 @@ nv.models.scatter = function() {
                   series: series,
                   pos: [x(getX(point, d.point)) + margin.left, y(getY(point, d.point)) + margin.top],
                   seriesIndex: d.series,
-                  pointIndex: d.point
+                  pointIndex: d.point,
+                  e: d3.event
                 });
               })
               .on('mouseover', function(d) {
@@ -244,7 +244,8 @@ nv.models.scatter = function() {
                   series: series,
                   pos: [x(getX(point, d.point)) + margin.left, y(getY(point, d.point)) + margin.top],
                   seriesIndex: d.series,
-                  pointIndex: d.point
+                  pointIndex: d.point,
+                  e: d3.event
                 });
               })
               .on('mouseout', function(d, i) {
@@ -256,7 +257,8 @@ nv.models.scatter = function() {
                   point: point,
                   series: series,
                   seriesIndex: d.series,
-                  pointIndex: d.point
+                  pointIndex: d.point,
+                  e: d3.event
                 });
               });
 
@@ -289,7 +291,8 @@ nv.models.scatter = function() {
                   series: series,
                   pos: [x(getX(point, i)) + margin.left, y(getY(point, i)) + margin.top],
                   seriesIndex: d.series,
-                  pointIndex: i
+                  pointIndex: i,
+                  e: d3.event
                 });
               })
               .on('mouseover', function(d,i) {
@@ -302,7 +305,8 @@ nv.models.scatter = function() {
                   series: series,
                   pos: [x(getX(point, i)) + margin.left, y(getY(point, i)) + margin.top],
                   seriesIndex: d.series,
-                  pointIndex: i
+                  pointIndex: i,
+                  d3.event
                 });
               })
               .on('mouseout', function(d,i) {
@@ -314,7 +318,8 @@ nv.models.scatter = function() {
                   point: point,
                   series: series,
                   seriesIndex: d.series,
-                  pointIndex: i
+                  pointIndex: i,
+                  e: d3.event
                 });
               });
           }


### PR DESCRIPTION
Adding d3.event to scatter event listeners to maintain consistency between models.  In the historical bar chart they are included, but not the line which uses the scatters events.