### PR TITLE
Fix bug of updateFisheye when you filtered out some data

### DIFF
--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -315,6 +315,7 @@ nv.models.scatterChart = function() {
         y.distortion(fisheye).focus(mouse[1]);
 
         g.select('.nv-scatterWrap')
+            .datum(data.filter(function(d) { return !d.disabled }))
             .call(scatter);
 
         g.select('.nv-x.nv-axis').call(xAxis);


### PR DESCRIPTION
Hi,

This patch fixes a bug when you filtered out some datapoints by clicking legends, and moving mouse around the chart.