### PR TITLE
[Makefile] Understandable error messages from uglifyjs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ nv.d3.js: Makefile
 
 %.min.js:: Makefile
 	rm -f $@
-	cat $(filter %.js,$^) | $(JS_COMPILER) >> $@
+	$(JS_COMPILER) nv.d3.js >> $@
 
 clean:
 	rm -rf nv.d3.js nv.d3.min.js


### PR DESCRIPTION
When running make, I used to get the following error message on a parse error, regardless of what file actually contained the parse error:
WARN: ERROR: Unexpected token: eof (undefined) [-:2019,8]

With this, change, the error message is actually understandable, ie:
WARN: ERROR: Unexpected token: name (asdfkl) [nv.d3.js:6349,4]
