### PR TITLE
Allow tooltips to override the X and Y format

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -20,7 +20,7 @@ nv.models.lineChart = function() {
     , tooltips = true
     , tooltip = function(key, x, y, e, graph) {
         return '<h3>' + key + '</h3>' +
-               '<p>' +  y + ' at ' + x + '</p>'
+               '<p>' +  yAxis.tickFormat()(y) + ' at ' + xAxis.tickFormat()(x) + '</p>'
       }
     , x
     , y
@@ -60,8 +60,8 @@ nv.models.lineChart = function() {
 
     var left = e.pos[0] + ( offsetElement.offsetLeft || 0 ),
         top = e.pos[1] + ( offsetElement.offsetTop || 0),
-        x = xAxis.tickFormat()(lines.x()(e.point, e.pointIndex)),
-        y = yAxis.tickFormat()(lines.y()(e.point, e.pointIndex)),
+        x = lines.x()(e.point, e.pointIndex),
+        y = lines.y()(e.point, e.pointIndex),
         content = tooltip(e.series.key, x, y, e, chart);
 
     nv.tooltip.show([left, top], content, null, null, offsetElement);

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -21,7 +21,7 @@ nv.models.stackedAreaChart = function() {
     , tooltips = true
     , tooltip = function(key, x, y, e, graph) {
         return '<h3>' + key + '</h3>' +
-               '<p>' +  y + ' on ' + x + '</p>'
+               '<p>' +  yAxis.tickFormat()(y) + ' on ' + xAxis.tickFormat()(x) + '</p>'
       }
     , x //can be accessed via chart.xScale()
     , y //can be accessed via chart.yScale()
@@ -56,8 +56,8 @@ nv.models.stackedAreaChart = function() {
   var showTooltip = function(e, offsetElement) {
     var left = e.pos[0] + ( offsetElement.offsetLeft || 0 ),
         top = e.pos[1] + ( offsetElement.offsetTop || 0),
-        x = xAxis.tickFormat()(stacked.x()(e.point, e.pointIndex)),
-        y = yAxis.tickFormat()(stacked.y()(e.point, e.pointIndex)),
+        x = stacked.x()(e.point, e.pointIndex),
+        y = stacked.y()(e.point, e.pointIndex),
         content = tooltip(e.series.key, x, y, e, chart);
 
     nv.tooltip.show([left, top], content, e.value < 0 ? 'n' : 's', null, offsetElement);


### PR DESCRIPTION
We needed to display the values differently on the axis versus the
tooltip, so this preserves the default behavior, but allows the consumer
to override the format in the tooltip.
