### PR TITLE
fixed invalid html in parallel coordinate example

### DIFF
--- a/examples/parallelCoordinates.html
+++ b/examples/parallelCoordinates.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <link href="../src/nv.d3.css" rel="stylesheet" type="text/css">
-<script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>>
+<script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
 <script src="../lib/d3.v2.js"></script>
 <script src="../nv.d3.js"></script>
 <script type="text/javascript" src="../src/utils.js"></script>


### PR DESCRIPTION
I noticed an extra bracket on the page from some invalid HTML.  It's a small fix but it disturbed me.
