### PR TITLE
Fixes Issue #109 - Prototype.js breaks StackedAreaChart

### DIFF
--- a/src/models/stackedArea.js
+++ b/src/models/stackedArea.js
@@ -25,7 +25,7 @@ nv.models.stackedArea = function() {
 
   scatter
     .size(2.2) // default size
-    .sizeDomain([2.2]) // all the same size by default
+    .sizeDomain([2.2,2.2]) // all the same size by default
     ;
 
   /************************************


### PR DESCRIPTION
It appears the specification of the sizeDomain as a single element
array causes d3.js to use the wrong interpolatin function internally.
