### PR TITLE
Allowing events to bubble so charts can be interactive

### DIFF
--- a/src/models/discreteBar.js
+++ b/src/models/discreteBar.js
@@ -157,7 +157,7 @@ nv.models.discreteBar = function() {
               seriesIndex: d.series,
               e: d3.event
             });
-            d3.event.stopPropagation();
+            //d3.event.stopPropagation();
           })
           .on('dblclick', function(d,i) {
             dispatch.elementDblClick({
@@ -169,7 +169,7 @@ nv.models.discreteBar = function() {
               seriesIndex: d.series,
               e: d3.event
             });
-            d3.event.stopPropagation();
+            //d3.event.stopPropagation();
           });
 
       barsEnter.append('rect')

--- a/src/models/historicalBar.js
+++ b/src/models/historicalBar.js
@@ -143,7 +143,7 @@ nv.models.historicalBar = function() {
                     e: d3.event,
                     id: id
                 });
-              d3.event.stopPropagation();
+              //d3.event.stopPropagation();
           })
           .on('dblclick', function(d,i) {
               dispatch.elementDblClick({
@@ -155,7 +155,7 @@ nv.models.historicalBar = function() {
                   e: d3.event,
                   id: id
               });
-              d3.event.stopPropagation();
+              //d3.event.stopPropagation();
           });
 
       bars

--- a/src/models/indentedTree.js
+++ b/src/models/indentedTree.js
@@ -181,7 +181,7 @@ nv.models.indentedTree = function() {
 
       // Toggle children on click.
       function click(d, _, unshift) {
-        d3.event.stopPropagation();
+        //d3.event.stopPropagation();
 
         if(d3.event.shiftKey && !unshift) {
           //If you shift-click, it'll toggle fold all the children, instead of itself

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -230,7 +230,7 @@ nv.models.multiBar = function() {
               seriesIndex: d.series,
               e: d3.event
             });
-            d3.event.stopPropagation();
+            //d3.event.stopPropagation();
           })
           .on('dblclick', function(d,i) {
             dispatch.elementDblClick({
@@ -242,7 +242,7 @@ nv.models.multiBar = function() {
               seriesIndex: d.series,
               e: d3.event
             });
-            d3.event.stopPropagation();
+            //d3.event.stopPropagation();
           });
       bars
           .attr('class', function(d,i) { return getY(d,i) < 0 ? 'nv-bar negative' : 'nv-bar positive'})

--- a/src/models/multiBarHorizontal.js
+++ b/src/models/multiBarHorizontal.js
@@ -200,7 +200,7 @@ nv.models.multiBarHorizontal = function() {
               seriesIndex: d.series,
               e: d3.event
             });
-            d3.event.stopPropagation();
+            //d3.event.stopPropagation();
           })
           .on('dblclick', function(d,i) {
             dispatch.elementDblClick({
@@ -212,7 +212,7 @@ nv.models.multiBarHorizontal = function() {
               seriesIndex: d.series,
               e: d3.event
             });
-            d3.event.stopPropagation();
+            //d3.event.stopPropagation();
           });
 
 

--- a/src/models/multiBarTimeSeries.js
+++ b/src/models/multiBarTimeSeries.js
@@ -201,7 +201,7 @@ nv.models.multiBarTimeSeries = function() {
               seriesIndex: d.series,
               e: d3.event
             });
-            d3.event.stopPropagation();
+            //d3.event.stopPropagation();
           })
           .on('dblclick', function(d,i) {
             dispatch.elementDblClick({
@@ -213,7 +213,7 @@ nv.models.multiBarTimeSeries = function() {
               seriesIndex: d.series,
               e: d3.event
             });
-            d3.event.stopPropagation();
+            //d3.event.stopPropagation();
           });
       bars
           .attr('class', function(d,i) { return getY(d,i) < 0 ? 'nv-bar negative' : 'nv-bar positive'})

--- a/src/models/ohlcBar.js
+++ b/src/models/ohlcBar.js
@@ -181,7 +181,7 @@ nv.models.ohlcBar = function() {
                     e: d3.event,
                     id: id
                 });
-              d3.event.stopPropagation();
+              //d3.event.stopPropagation();
           })
           .on('dblclick', function(d,i) {
               dispatch.elementDblClick({
@@ -193,7 +193,7 @@ nv.models.ohlcBar = function() {
                   e: d3.event,
                   id: id
               });
-              d3.event.stopPropagation();
+              //d3.event.stopPropagation();
           });
 
       ticks

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -115,7 +115,7 @@ nv.models.pie = function() {
                     pos: d3.event,
                     id: id
                 });
-                d3.event.stopPropagation();
+                //d3.event.stopPropagation();
               })
               .on('dblclick', function(d,i) {
                 dispatch.elementDblClick({
@@ -126,7 +126,7 @@ nv.models.pie = function() {
                     pos: d3.event,
                     id: id
                 });
-                d3.event.stopPropagation();
+                //d3.event.stopPropagation();
               });
 
         slices


### PR DESCRIPTION
- This is extremely useful for capturing user input and driving the GUI as a result; removed the `stopPropagation()` because it assumes how the charts will be used and that's a very narrow use case
