### PR TITLE
Fix onresize error with no chart on page

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -30,6 +30,7 @@ nv.utils.windowSize = function() {
 // Easy way to bind multiple functions to window.onresize
 // TODO: give a way to remove a function after its bound, other than removing all of them
 nv.utils.windowResize = function(fun){
+  if (fun === undefined) return;
   var oldresize = window.onresize;
 
   window.onresize = function(e) {


### PR DESCRIPTION
When loading nv3d without creating a chart, `nv.utils.windowResize` is called somewhere with an undefined argument, so we should check if it is undefined and not try to replace the old event handler, otherwise every resize event generates an error because `fun` is undefined.

I was able to produce  by including the following libs and triggering onresize events.

```
nvd3/lib/d3.v2.js
nvd3/src/core.js
nvd3/src/tooltip.js
nvd3/src/utils.js
nvd3/src/models/lineWithFocusChart.js
nvd3/src/models/legend.js
nvd3/src/models/axis.js
nvd3/src/models/line.js
nvd3/src/models/scatter.js
```

Sponsored-by: CentroNet Marketing
