### PR TITLE
Bug Fix - Prevents tooltip from showing with Date data type in line charts

### DIFF
--- a/nv.d3.js
+++ b/nv.d3.js
@@ -10028,8 +10028,11 @@ nv.models.scatter = function() {
                 // *Injecting series and point index for reference
                 /* *Adding a 'jitter' to the points, because there's an issue in d3.geom.voronoi.
                 */
-                var pX = getX(point,pointIndex) + Math.random() * 1e-7;
-                var pY = getY(point,pointIndex) + Math.random() * 1e-7;
+                var pointX  = getX(point,pointIndex)
+                var pX      = !pointX instanceof Date ? pointX + Math.random() * 1e-7 : pointX
+                    
+                var pointY  = getY(point,pointIndex)
+                var pY     = !pointY instanceof Date ? pointY + Math.random() * 1e-7 : pointY
 
                 return [x(pX), 
                         y(pY), 


### PR DESCRIPTION
Tooltips do not work when using Date objects for X or Y values with line charts.  The root of the problem comes from trying to add a "jitter" to these points.  In firebug I receive the following warning:

`Unexpected value NaN parsing cx attribute.`

My fix checks for a Date type first before applying the jitter which removes the NaN warning and fixes the tooltip.

(Sorry for the large chunk of changes in this commit I couldn't figure out why git read the change this way.  I only made changes to lines 10,031 - 10,035 )