### PR TITLE
Add ability to provide custom labels to bullet chart.

### DIFF
--- a/examples/bulletChartWithLabels.html
+++ b/examples/bulletChartWithLabels.html
@@ -12,7 +12,7 @@ body {
 
 <br> <br> <br> <br> <br>
 
-<div class="gallery" id="chart"></div>
+<div class="gallery with-transitions" id="chart"></div>
 
 <script src="../lib/d3.v3.js"></script>
 <script src="../nv.d3.js"></script>

--- a/src/models/bullet.js
+++ b/src/models/bullet.js
@@ -147,14 +147,14 @@ nv.models.bullet = function() {
           .on('mouseover', function() {
               dispatch.elementMouseover({
                 value: measurez[0],
-                label: measureLabelz[0] ? measureLabelz[0] : 'Current',
+                label: measureLabelz[0] || 'Current',
                 pos: [x1(measurez[0]), availableHeight/2]
               })
           })
           .on('mouseout', function() {
               dispatch.elementMouseout({
                 value: measurez[0],
-                label: measureLabelz[0] ? measureLabelz[0] : 'Current'
+                label: measureLabelz[0] || 'Current'
               })
           })
 
@@ -166,14 +166,14 @@ nv.models.bullet = function() {
             .on('mouseover', function() {
               dispatch.elementMouseover({
                 value: markerz[0],
-                label: markerLabelz[0] ? markerLabelz[0] : 'Previous',
+                label: markerLabelz[0] || 'Previous',
                 pos: [x1(markerz[0]), availableHeight/2]
               })
             })
             .on('mouseout', function() {
               dispatch.elementMouseout({
                 value: markerz[0],
-                label: markerLabelz[0] ? markerLabelz[0] : 'Previous'
+                label: markerLabelz[0] || 'Previous'
               })
             });
       } else {
@@ -183,7 +183,7 @@ nv.models.bullet = function() {
 
       wrap.selectAll('.nv-range')
           .on('mouseover', function(d,i) {
-            var label = rangeLabelz[i] ? rangeLabelz[i] : !i ? "Maximum" : i == 1 ? "Mean" : "Minimum";
+            var label = rangeLabelz[i] || (!i ? "Maximum" : i == 1 ? "Mean" : "Minimum");
 
             dispatch.elementMouseover({
               value: d,
@@ -192,7 +192,7 @@ nv.models.bullet = function() {
             })
           })
           .on('mouseout', function(d,i) {
-            var label = rangeLabelz[i] ? rangeLabelz[i] : !i ? "Maximum" : i == 1 ? "Mean" : "Minimum";
+            var label = rangeLabelz[i] || (!i ? "Maximum" : i == 1 ? "Mean" : "Minimum");
 
             dispatch.elementMouseout({
               value: d,


### PR DESCRIPTION
I want the ability to provide custom labels to the bullet chart. This could be accomplished by manually hacking up the tooltipContent and checking against the default labels, but that seemed unmaintainable.

I added a way to specify labels as part of the data. Providing them as separate elements may not be the most elegant way to do this, but it seemed the cleanest way to add the functionality while minimizing the impact and likelihood of introducing side effects. 

I added a separate bullet chart example to show specifying labels, but I don't know that it's important enough functionality to warrant a separate example in the main repo. 
