### PR TITLE
Add brushExtent to chart to enable the ability to set default focus range

### DIFF
--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -1,4 +1,3 @@
-
 nv.models.lineWithFocusChart = function() {
 
   //============================================================
@@ -550,6 +549,12 @@ nv.models.lineWithFocusChart = function() {
     if (!arguments.length) return yAxis.tickFormat();
     yAxis.tickFormat(_);
     y2Axis.tickFormat(_);
+    return chart;
+  };
+  
+  chart.brushExtent = function(_) {
+    if (!arguments.length) return brushExtent;
+    brushExtent = _;
     return chart;
   };
 


### PR DESCRIPTION
There is a brushExtent when init, so I guess maybe you guys just forgot to put the public function available.
