### PR TITLE
Added url support to discreteBarChart point

### DIFF
--- a/examples/discreteBarChart.html
+++ b/examples/discreteBarChart.html
@@ -56,11 +56,13 @@ historicalBarChart = [
     values: [
       { 
         "label" : "A" ,
-        "value" : 29.765957771107
+        "value" : 29.765957771107,
+        "url" : "http://www.google.com/"
       } , 
       { 
         "label" : "B" , 
-        "value" : 0
+        "value" : 0,
+        "url" : "http://d3js.org/"
       } , 
       { 
         "label" : "C" , 
@@ -68,7 +70,8 @@ historicalBarChart = [
       } , 
       { 
         "label" : "D" , 
-        "value" : 196.45946739256
+        "value" : 196.45946739256,
+        "url" : "http://nvd3.org/"
       } , 
       { 
         "label" : "E" ,

--- a/src/models/discreteBar.js
+++ b/src/models/discreteBar.js
@@ -172,6 +172,12 @@ nv.models.discreteBar = function() {
             d3.event.stopPropagation();
           });
 
+      if (function(d,i) {return d.url !== undefined})
+      {
+        barsEnter = barsEnter.append('a')
+          .attr('xlink:href', function(d,i) {return d.url});
+      }
+
       barsEnter.append('rect')
           .attr('height', 0)
           .attr('width', x.rangeBand() * .9 / data.length )
@@ -189,11 +195,11 @@ nv.models.discreteBar = function() {
 
       bars
           .attr('class', function(d,i) { return getY(d,i) < 0 ? 'nv-bar negative' : 'nv-bar positive' })
-          .style('fill', function(d,i) { return d.color || color(d,i) })
-          .style('stroke', function(d,i) { return d.color || color(d,i) })
         .select('rect')
           .attr('class', rectClass)
-          .attr('width', x.rangeBand() * .9 / data.length);
+          .attr('width', x.rangeBand() * .9 / data.length)
+          .style('fill', function(d,i) { return d.color || color(d,i) })
+          .style('stroke', function(d,i) { return d.color || color(d,i) });
       d3.transition(bars)
         //.delay(function(d,i) { return i * 1200 / data[0].values.length })
           .attr('transform', function(d,i) {


### PR DESCRIPTION
If point has url, add 'a' container with 'xlink:href' within 'g'
(seems nicer to change 'g' to 'a' but this breaks resizing);
Move fill/stroke onto rect as they didn't get the 'g' style with 'a'
inbetwen;
Updated example to include some urls