### PR TITLE
Add a labelType method for pieCharts

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -17,6 +17,7 @@ nv.models.pie = function() {
     , showLabels = true
     , pieLabelsOutside = true
     , donutLabelsOutside = false
+    , labelType = "key"
     , labelThreshold = .02 //if slice percentage is under this, don't show label
     , donut = false
     , labelSunbeamLayout = false
@@ -212,7 +213,12 @@ nv.models.pie = function() {
                 .style('text-anchor', labelSunbeamLayout ? ((d.startAngle + d.endAngle) / 2 < Math.PI ? 'start' : 'end') : 'middle') //center the text on it's origin or begin/end if orthogonal aligned
                 .text(function(d, i) {
                   var percent = (d.endAngle - d.startAngle) / (2 * Math.PI);
-                  return (d.value && percent > labelThreshold) ? getX(d.data) : '';
+                  var labelTypes = {
+                    "key" : getX(d.data),
+                    "value": getY(d.data),
+                    "percent": d3.format('%')(percent)
+                  };
+                  return (d.value && percent > labelThreshold) ? labelTypes[labelType] : '';
                 });
 
             var textBox = slice.select('text').node().getBBox();
@@ -329,6 +335,12 @@ nv.models.pie = function() {
   chart.pieLabelsOutside = function(_) {
     if (!arguments.length) return pieLabelsOutside;
     pieLabelsOutside = _;
+    return chart;
+  };
+
+  chart.labelType = function(_) {
+    if (!arguments.length) return labelType;
+    labelType = _;
     return chart;
   };
 

--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -228,7 +228,7 @@ nv.models.pieChart = function() {
   chart.dispatch = dispatch;
   chart.pie = pie;
 
-  d3.rebind(chart, pie, 'valueFormat', 'values', 'x', 'y', 'description', 'id', 'showLabels', 'donutLabelsOutside', 'pieLabelsOutside', 'donut', 'donutRatio', 'labelThreshold');
+  d3.rebind(chart, pie, 'valueFormat', 'values', 'x', 'y', 'description', 'id', 'showLabels', 'donutLabelsOutside', 'pieLabelsOutside', 'labelType', 'donut', 'donutRatio', 'labelThreshold');
 
   chart.margin = function(_) {
     if (!arguments.length) return margin;


### PR DESCRIPTION
This pull request adds a `labelType` method for `pieChart`s to give to option to show the 'key', 'value', or 'percent' on the slice's label. With this change, using `.showLabels(true)` still defaults to this:

![screen shot 2013-08-07 at 8-7-13 10 36 07 pm](https://f.cloud.github.com/assets/1975147/929195/632fcf7c-ffd3-11e2-8ac2-23ae8757c024.png)

but now you have the option to use `.labelType("percent")` to show this:

![screen shot 2013-08-07 at 8-7-13 10 36 24 pm](https://f.cloud.github.com/assets/1975147/929198/82c319a2-ffd3-11e2-8e80-4fd5da33f4f3.png)

Open to feedback. Let me know what you think.
