### PR TITLE
Passing the correct data object to the color function for the pie chart

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -130,8 +130,8 @@ nv.models.pie = function() {
               });
 
         slices
-            .attr('fill', function(d,i) { return color(d, i); })
-            .attr('stroke', function(d,i) { return color(d, i); });
+            .attr('fill', function(d,i) { return color(d.data, i); })
+            .attr('stroke', function(d,i) { return color(d.data, i); });
 
         var paths = ae.append('path')
             .each(function(d) { this._current = d; });


### PR DESCRIPTION
According to nv.utils.getColor(), The color() function should return a "color" property present in the data packet that draws a slice.
In the case of the pie chart, the data passed, does not contain the user created data, but the parent object that contains it.
This patch corrects that, and passes the right object to the color method, so it can display user defined custom colors to render an element in the data set for the pie chart.