### PR TITLE
Expose stack offset

### DIFF
--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -16,6 +16,7 @@ nv.models.multiBar = function() {
     , forceY = [0] // 0 is forced by default.. this makes sense for the majority of bar graphs... user can always do chart.forceY([]) to remove
     , clipEdge = true
     , stacked = false
+    , stackOffset = 'zero' // options include 'silhouette', 'wiggle', 'expand', 'zero', or a custom function
     , color = nv.utils.defaultColor()
     , hideable = false
     , barColor = null // adding the ability to set the color for each rather than the whole group
@@ -60,7 +61,7 @@ nv.models.multiBar = function() {
 
       if (stacked)
         data = d3.layout.stack()
-                 .offset('zero')
+                 .offset(stackOffset)
                  .values(function(d){ return d.values })
                  .y(getY)
                  (!data.length && hideable ? hideable : data);
@@ -396,6 +397,12 @@ nv.models.multiBar = function() {
   chart.stacked = function(_) {
     if (!arguments.length) return stacked;
     stacked = _;
+    return chart;
+  };
+
+  chart.stackOffset = function(_) {
+    if (!arguments.length) return stackOffset;
+    stackOffset = _;
     return chart;
   };
 

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -393,7 +393,7 @@ nv.models.multiBarChart = function() {
   chart.yAxis = yAxis;
 
   d3.rebind(chart, multibar, 'x', 'y', 'xDomain', 'yDomain', 'xRange', 'yRange', 'forceX', 'forceY', 'clipEdge',
-   'id', 'stacked', 'delay', 'barColor','groupSpacing');
+   'id', 'stacked', 'stackOffset', 'delay', 'barColor','groupSpacing');
 
   chart.margin = function(_) {
     if (!arguments.length) return margin;


### PR DESCRIPTION
Fix #225 -
Thankfully, d3 has a percentage-based stacked column baked into the stack layout in the form of `stack.offset`. All you need to do is set the offset to expand and you get a chart like this:

![screen shot 2013-08-24 at 8-24-13 7 12 01 pm](https://f.cloud.github.com/assets/1975147/1021599/a47b941a-0d12-11e3-8a5b-6064dd7c8bfd.png)

This PR exposes the offset options. The only thing remaining is to change the yAxis format to %, but I figured that it was best to leave the format up to the user, but feel free to add if you think it should be the default format.
