### PR TITLE
Allows for pie chart colors to be set through data. Fixes #224.

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -130,8 +130,8 @@ nv.models.pie = function() {
               });
 
         slices
-            .attr('fill', function(d,i) { return color(d, i); })
-            .attr('stroke', function(d,i) { return color(d, i); });
+            .attr('fill', function(d,i) { return d.data.color || color(d, i); })
+            .attr('stroke', function(d,i) { return d.data.color || color(d, i); });
 
         var paths = ae.append('path')
             .each(function(d) { this._current = d; });


### PR DESCRIPTION
This commit allows for colors to be set through the data. It follows the same pattern that has been used in multiple other NVD3 modules, such as [legend.js](https://github.com/novus/nvd3/blob/master/src/models/legend.js#L62) and [sparkline.js](https://github.com/novus/nvd3/blob/master/src/models/sparkline.js#L61). Pie charts nest their data differently; using `d.data` is common throughout the [pie.js](https://github.com/novus/nvd3/blob/master/src/models/pie.js#L91) file.

This example has been test successfully in both `examples/pie.html` and `examples/pieChart.html`. The color data can be set in the following way:

```
{
  key: "One",
  y: 5,
  color: "#ffff00"
}
```
