### PR TITLE
Remove singlePoint variable that is assigned but not used in bar models

### DIFF
--- a/src/models/multiBarTimeSeries.js
+++ b/src/models/multiBarTimeSeries.js
@@ -79,7 +79,6 @@ nv.models.multiBarTimeSeries = function() {
 
 
       // If scale's domain don't have a range, slightly adjust to make one... so a chart can show a single data point
-      if (x.domain()[0] === x.domain()[1] || y.domain()[0] === y.domain()[1]) singlePoint = true;
       if (x.domain()[0] === x.domain()[1])
         x.domain()[0] ?
             x.domain([x.domain()[0] - x.domain()[0] * 0.01, x.domain()[1] + x.domain()[1] * 0.01])

--- a/src/models/ohlcBar.js
+++ b/src/models/ohlcBar.js
@@ -64,7 +64,6 @@ nv.models.ohlcBar = function() {
           .range(yRange || [availableHeight, 0]);
 
       // If scale's domain don't have a range, slightly adjust to make one... so a chart can show a single data point
-      if (x.domain()[0] === x.domain()[1] || y.domain()[0] === y.domain()[1]) singlePoint = true;
       if (x.domain()[0] === x.domain()[1])
         x.domain()[0] ?
             x.domain([x.domain()[0] - x.domain()[0] * 0.01, x.domain()[1] + x.domain()[1] * 0.01])


### PR DESCRIPTION
I noticed this variable wasn't being referenced by the model at any point.

This variable was also being assigned as a property on the global object (`window` in browsers) instead of being declared locally with a `var` statement.
