### PR TITLE
Expose the 'controls' property on more chart models

### DIFF
--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -605,6 +605,7 @@ nv.models.cumulativeLineChart = function() {
   chart.dispatch = dispatch;
   chart.lines = lines;
   chart.legend = legend;
+  chart.controls = controls;
   chart.xAxis = xAxis;
   chart.yAxis = yAxis;
   chart.interactiveLayer = interactiveLayer;

--- a/src/models/lineWithFisheyeChart.js
+++ b/src/models/lineWithFisheyeChart.js
@@ -236,6 +236,7 @@ nv.models.lineChart = function() {
 
   chart.dispatch = dispatch;
   chart.legend = legend;
+  chart.controls = controls;
   chart.xAxis = xAxis;
   chart.yAxis = yAxis;
 

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -389,6 +389,7 @@ nv.models.multiBarChart = function() {
   // expose chart's sub-components
   chart.dispatch = dispatch;
   chart.multibar = multibar;
+  chart.controls = controls;
   chart.legend = legend;
   chart.xAxis = xAxis;
   chart.yAxis = yAxis;

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -339,6 +339,7 @@ nv.models.multiBarHorizontalChart = function() {
   chart.dispatch = dispatch;
   chart.multibar = multibar;
   chart.legend = legend;
+  chart.controls = controls;
   chart.xAxis = xAxis;
   chart.yAxis = yAxis;
 

--- a/src/models/multiBarTimeSeriesChart.js
+++ b/src/models/multiBarTimeSeriesChart.js
@@ -314,6 +314,7 @@ nv.models.multiBarTimeSeriesChart = function() {
   chart.dispatch = dispatch;
   chart.multibar = multibar;
   chart.legend = legend;
+  chart.controls = controls;
   chart.xAxis = xAxis;
   chart.yAxis = yAxis;
 


### PR DESCRIPTION
The 'controls' object was already exposed on some models, this pull request exposes it on the others that have a controls object.

This would, for example, allow you to turn off right alignment (which keeps the controls from running into the legend) when dealing with a small chart.