### PR TITLE
replace axis d3 scale when scatterChart.js scale is replaced

### DIFF
--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -151,6 +151,8 @@ nv.models.scatterChart = function() {
 
       //------------------------------------------------------------
       // Setup Scales
+      x = scatter.xScale();
+      y = scatter.yScale();
 
       x0 = x0 || x;
       y0 = y0 || y;


### PR DESCRIPTION
Minor tweak to ensure that when replacing the scale for the scatterChart that the axis scale is also replaced.  Now mirrors ScatterChartWithLine.js