### PR TITLE
version mismatch 1.1.12 vs 1.1.13

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "nvd3",
-  "version": "1.1.12-beta",
+  "version": "1.1.13-beta",
   "homepage": "http://www.nvd3.org",
   "authors": [
     "Bob Monteverde",


### PR DESCRIPTION
bower fails to install 1.1.13 because of this
