### PR TITLE
Create areas with upper/lower domain

### DIFF
--- a/examples/lineChart.html
+++ b/examples/lineChart.html
@@ -41,8 +41,7 @@ svg {
 </div>
 
 <script src="../lib/d3.v3.js"></script>
-<script src="../src/intro.js"></script>
-<script src="../src/core.js"></script>
+<script src="../nv.d3.js"></script>
 <script src="../src/tooltip.js"></script>
 <script src="../src/utils.js"></script>
 <script src="../src/interactiveLayer.js"></script>

--- a/examples/lineChart.html
+++ b/examples/lineChart.html
@@ -41,7 +41,8 @@ svg {
 </div>
 
 <script src="../lib/d3.v3.js"></script>
-<script src="../nv.d3.js"></script>
+<script src="../src/intro.js"></script>
+<script src="../src/core.js"></script>
 <script src="../src/tooltip.js"></script>
 <script src="../src/utils.js"></script>
 <script src="../src/interactiveLayer.js"></script>
@@ -91,13 +92,15 @@ nv.addGraph(function() {
 
 function sinAndCos() {
   var sin = [],
+  	sin3 = [],
     cos = [],
     rand = [],
     rand2 = []
     ;
 
   for (var i = 0; i < 100; i++) {
-    sin.push({x: i, y: i % 10 == 5 ? null : Math.sin(i/10) }); //the nulls are to show how defined works
+    sin.push({x: i, y: i % 10 == 5 ? null : [Math.sin(i/10),Math.sin(i/10)/2]}); //the nulls are to show how defined works
+    sin3.push({x: i, y: i % 10 == 5 ? null : Math.sin(i/10)/3}); //the nulls are to show how defined works
     cos.push({x: i, y: .5 * Math.cos(i/10)});
     rand.push({x:i, y: Math.random() / 10});
     rand2.push({x: i, y: Math.cos(i/10) + Math.random() / 10 })
@@ -109,6 +112,12 @@ function sinAndCos() {
       values: sin,
       key: "Sine Wave",
       color: "#ff7f0e"
+    },
+    {
+      area: true,
+      values: sin3,
+      key: "Sine Wave/3",
+      color: "#ff0000"
     },
     {
       values: cos,

--- a/src/models/line.js
+++ b/src/models/line.js
@@ -138,9 +138,6 @@ nv.models.line = function() {
                 .x(function(d,i) { return nv.utils.NaNtoZero(x0(getX(d,i))) })
                 .y0(function(d,i) { return nv.utils.NaNtoZero(y0(getY(d,i))) })
                 .y1(function(d,i) { return y0( getYMin(d,i) ) })
-                //.y1(function(d,i) { return y0( nv.utils.NaNtoZero(getYMin(d,i)) ) })
-                //.y1(function(d,i) { return y0( y.domain()[0] <= 0 ? y.domain()[1] >= 0 ? 0 : y.domain()[1] : y.domain()[0] ) })
-                //.y1(function(d,i) { return y0(0) }) //assuming 0 is within y domain.. may need to tweak this
                 .apply(this, [d.values])
           });
       groups.exit().selectAll('path.nv-area')
@@ -155,9 +152,6 @@ nv.models.line = function() {
                 .x(function(d,i) { return nv.utils.NaNtoZero(x(getX(d,i))) })
                 .y0(function(d,i) { return nv.utils.NaNtoZero(y(getY(d,i))) })
                 .y1(function(d,i) { return y( getYMin(d,i) ) })
-                //.y1(function(d,i) { return y( (isArrayY(d) ? nv.utils.NaNtoZero(y0(getYMin(d,i))) : 0) ) })
-                //.y1(function(d,i) { return y( y.domain()[0] <= 0 ? y.domain()[1] >= 0 ? 0 : y.domain()[1] : y.domain()[0] ) })
-                //.y1(function(d,i) { return y0(0) }) //assuming 0 is within y domain.. may need to tweak this
                 .apply(this, [d.values])
           });
 

--- a/src/models/line.js
+++ b/src/models/line.js
@@ -13,7 +13,9 @@ nv.models.line = function() {
     , height = 500
     , color = nv.utils.defaultColor() // a function that returns a color
     , getX = function(d) { return d.x } // accessor to get the x value from a data point
-    , getY = function(d) { return d.y } // accessor to get the y value from a data point
+    , getY = function(d) { return (d.y == null || !Array.isArray(d.y) ? d.y : d.y[0]) } // accessor to get the y value from a data point
+    , getYMin = function(d) { return (d.y == null ? null : (Array.isArray(d.y) ? d.y[1] : y.domain()[0] <= 0 ? y.domain()[1] >= 0 ? 0 : y.domain()[1] : y.domain()[0]) ) } // accessor to get the y value from a data point
+    , isArrayY = function(d) { return (d.y == null ? false : Array.isArray(d.y)) }
     , defined = function(d,i) { return !isNaN(getY(d,i)) && getY(d,i) !== null } // allows a line to be not continuous when it is not defined
     , isArea = function(d) { return d.area } // decides if a line is an area or just a line
     , clipEdge = false // if true, masks lines within x and y scale
@@ -135,7 +137,9 @@ nv.models.line = function() {
                 .defined(defined)
                 .x(function(d,i) { return nv.utils.NaNtoZero(x0(getX(d,i))) })
                 .y0(function(d,i) { return nv.utils.NaNtoZero(y0(getY(d,i))) })
-                .y1(function(d,i) { return y0( y.domain()[0] <= 0 ? y.domain()[1] >= 0 ? 0 : y.domain()[1] : y.domain()[0] ) })
+                .y1(function(d,i) { return y0( getYMin(d,i) ) })
+                //.y1(function(d,i) { return y0( nv.utils.NaNtoZero(getYMin(d,i)) ) })
+                //.y1(function(d,i) { return y0( y.domain()[0] <= 0 ? y.domain()[1] >= 0 ? 0 : y.domain()[1] : y.domain()[0] ) })
                 //.y1(function(d,i) { return y0(0) }) //assuming 0 is within y domain.. may need to tweak this
                 .apply(this, [d.values])
           });
@@ -150,7 +154,9 @@ nv.models.line = function() {
                 .defined(defined)
                 .x(function(d,i) { return nv.utils.NaNtoZero(x(getX(d,i))) })
                 .y0(function(d,i) { return nv.utils.NaNtoZero(y(getY(d,i))) })
-                .y1(function(d,i) { return y( y.domain()[0] <= 0 ? y.domain()[1] >= 0 ? 0 : y.domain()[1] : y.domain()[0] ) })
+                .y1(function(d,i) { return y( getYMin(d,i) ) })
+                //.y1(function(d,i) { return y( (isArrayY(d) ? nv.utils.NaNtoZero(y0(getYMin(d,i))) : 0) ) })
+                //.y1(function(d,i) { return y( y.domain()[0] <= 0 ? y.domain()[1] >= 0 ? 0 : y.domain()[1] : y.domain()[0] ) })
                 //.y1(function(d,i) { return y0(0) }) //assuming 0 is within y domain.. may need to tweak this
                 .apply(this, [d.values])
           });
@@ -166,7 +172,7 @@ nv.models.line = function() {
               .interpolate(interpolate)
               .defined(defined)
               .x(function(d,i) { return nv.utils.NaNtoZero(x0(getX(d,i))) })
-              .y(function(d,i) { return nv.utils.NaNtoZero(y0(getY(d,i))) })
+              .y(function(d,i) { return (isArrayY(d) ? Infinity : nv.utils.NaNtoZero(y0(getY(d,i)))) })
           );
       groups.exit().selectAll('path.nv-line')
           .transition()
@@ -175,7 +181,7 @@ nv.models.line = function() {
               .interpolate(interpolate)
               .defined(defined)
               .x(function(d,i) { return nv.utils.NaNtoZero(x(getX(d,i))) })
-              .y(function(d,i) { return nv.utils.NaNtoZero(y(getY(d,i))) })
+              .y(function(d,i) { return (isArrayY(d) ? Infinity : nv.utils.NaNtoZero(y(getY(d,i)))) })
           );
       linePaths
           .transition()
@@ -184,7 +190,7 @@ nv.models.line = function() {
               .interpolate(interpolate)
               .defined(defined)
               .x(function(d,i) { return nv.utils.NaNtoZero(x(getX(d,i))) })
-              .y(function(d,i) { return nv.utils.NaNtoZero(y(getY(d,i))) })
+              .y(function(d,i) { return (isArrayY(d) ? Infinity : nv.utils.NaNtoZero(y(getY(d,i)))) })
           );
 
 


### PR DESCRIPTION
I've added the possibility to create an area with a upper/lower domain. The lower value of the existing area is always the same for all the serie. Now you can define a lower value for the area for each point:

![ae551a6a-3369-11e3-824b-dc80074f58c5](https://f.cloud.github.com/assets/5390887/1323922/85b4c83a-349f-11e3-9597-64d14f61e842.png)

To activate this option only need to pass a 2-value array to the y value of the area:

sin.push({x: i, y: i % 10 == 5 ? null : [Math.sin(i/10),Math.sin(i/10)/2]});

That don't affect to the existing line or area. An area with a single y value is represented as usual with a same lower value for all the area (normally 0 base).