### PR TITLE
Quick Fix: update func in sparklinePlus model throws errors

### DIFF
--- a/nv.d3.js
+++ b/nv.d3.js
@@ -13046,7 +13046,8 @@ nv.models.sparklinePlus = function() {
 
       
 
-      chart.update = function() { chart(selection) };
+      chart.update = function() { container.transition().call(chart) };
+      
       chart.container = this;
 
 

--- a/src/models/sparklinePlus.js
+++ b/src/models/sparklinePlus.js
@@ -36,7 +36,8 @@ nv.models.sparklinePlus = function() {
 
       
 
-      chart.update = function() { chart(selection) };
+      chart.update = function() { container.transition().call(chart) };
+      
       chart.container = this;
 
 


### PR DESCRIPTION
D3 expects each node to have a **transition** prop when updating a chart. Thus, calling the current update func for a sparklinePlus chart throws errors. This code contains a fix (no idea if it's the best fix, but it works).

Thanks for taking a look!
