### PR TITLE
Update nvd3 d3 dependency to ~ 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   ],
   "license": "Apache License, v2.0",
   "dependencies": {
-    "d3": "3.3.5"
+    "d3": "~3.3.5"
   },
   "ignore" : [
     "**/.*",


### PR DESCRIPTION
No conflicts with packages who also require d3 at a newer 3.3 version.
