### PR TITLE
Allow nvd3 to be installed via NPM and not just bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,25 @@
 {
   "name": "nvd3",
-  "version": "0.0.1",
+  "version": "1.1.14-beta",
+  "homepage": "http://www.nvd3.org",
+  "authors": [
+    "Bob Monteverde",
+    "Tyler Wolf",
+    "Robin Hu",
+    "Frank Shao"
+  ],
+  "description": "Re-usable charts and chart components for d3.",
+  "main": "nv.d3.js",
+  "keywords": [
+    "d3",
+    "visualization",
+    "svg",
+    "charts"
+  ],
+  "license": "Apache License, v2.0",
+  "dependencies": {
+    "d3": "~3.3.5"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "charts"
   ],
   "license": "Apache License, v2.0",
-  "dependencies": {
+  "peerDependencies": {
     "d3": "~3.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
We use NPM as our package manager (moved away from bower) and it would be great to be able to NPM install nvd3.