### PR TITLE
Pie Chart tooltip placement and style corrected.

### DIFF
--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -33,8 +33,8 @@ nv.models.pieChart = function() {
 
   var showTooltip = function(e, offsetElement) {
     var tooltipLabel = pie.description()(e.point) || pie.x()(e.point)
-    var left = e.pos[0] + ( (offsetElement && offsetElement.offsetLeft) || 0 ),
-        top = e.pos[1] + ( (offsetElement && offsetElement.offsetTop) || 0),
+    var left = e.pos[0] + ( (offsetElement && offsetElement.scrollLeft) || 0 ),
+        top = e.pos[1] + ( (offsetElement && offsetElement.scrollTop) || 0),
         y = pie.valueFormat()(pie.y()(e.point)),
         content = tooltip(tooltipLabel, y, e, chart);
 
@@ -162,8 +162,8 @@ nv.models.pieChart = function() {
         chart.update();
       });
 
-      pie.dispatch.on('elementMouseout.tooltip', function(e) {
-        dispatch.tooltipHide(e);
+      dispatch.on('tooltipShow', function (e) {
+        if (tooltips) showTooltip(e, that.parentNode);
       });
 
       // Update chart from a state object passed to event handler
@@ -192,16 +192,16 @@ nv.models.pieChart = function() {
   // Event Handling/Dispatching (out of chart's scope)
   //------------------------------------------------------------
 
-  pie.dispatch.on('elementMouseover.tooltip', function(e) {
-    e.pos = [e.pos[0] +  margin.left, e.pos[1] + margin.top];
+  pie.dispatch.on('elementMouseover.tooltip', function (e) {
+    e.pos = [e.pos[0] + margin.left, e.pos[1] + margin.top];
     dispatch.tooltipShow(e);
   });
 
-  dispatch.on('tooltipShow', function(e) {
-    if (tooltips) showTooltip(e);
+  pie.dispatch.on('elementMouseout.tooltip', function (e) {
+    dispatch.tooltipHide(e);
   });
 
-  dispatch.on('tooltipHide', function() {
+  dispatch.on('tooltipHide', function () {
     if (tooltips) nv.tooltip.cleanup();
   });
 

--- a/test/pieChartTest.html
+++ b/test/pieChartTest.html
@@ -23,7 +23,7 @@ text {
           <a href="ScatterChartTest.html">Scatter</a>
           <a href="realTimeChartTest.html">Real time test</a>
   </div>
-<div class='chart third' id="test1">
+<div class='chart third with-3d-shadow' id="test1">
   <h2>Standard Pie Chart</h2>
   <svg></svg>
 </div>


### PR DESCRIPTION
Pie Chart tooltip invocation logic adjusted:
1. Parent container scroll offset is properly applied
2. 'with-3d-shadow' style respected if applied to parent container
3. Pie chart tooltip events invocation made consistent with the other charts