### PR TITLE
left, bottom and right label positioning (+ some bugs)

### DIFF
--- a/nv.d3.js
+++ b/nv.d3.js
@@ -1147,7 +1147,7 @@ nv.utils.optionsFunc = function(args) {
           var w = (scale.range().length==2) ? scale.range()[1] : (scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]));
           axisLabel
               .attr('text-anchor', 'middle')
-              .attr('y', xLabelMargin)
+              .attr('y', xLabelMargin + (axisLabelDistance * -1))
               .attr('x', w/2);
           if (showMaxMin) {
           //if (showMaxMin && !isOrdinal) {
@@ -1186,7 +1186,7 @@ nv.utils.optionsFunc = function(args) {
           axisLabel
               .style('text-anchor', rotateYLabel ? 'middle' : 'begin')
               .attr('transform', rotateYLabel ? 'rotate(90)' : '')
-              .attr('y', rotateYLabel ? (-Math.max(margin.right,width) + 12) : -10) //TODO: consider calculating this based on largest tick width... OR at least expose this on chart
+              .attr('y', rotateYLabel ? (-Math.max(margin.right,width) + axisLabelDistance) : -10) //TODO: consider calculating this based on largest tick width... OR at least expose this on chart
               .attr('x', rotateYLabel ? (scale.range()[0] / 2) : axis.tickPadding());
           if (showMaxMin) {
             var axisMaxMin = wrap.selectAll('g.nv-axisMaxMin')
@@ -10323,14 +10323,16 @@ nv.models.pie = function() {
               .attr('class', 'nv-slice')
               .on('mouseover', function(d,i){
                 d3.select(this).classed('hover', true);
-                dispatch.elementMouseover({
-                    label: getX(d.data),
-                    value: getY(d.data),
-                    point: d.data,
-                    pointIndex: i,
-                    pos: [d3.event.pageX, d3.event.pageY],
-                    id: id
-                });
+                if(d3.event){
+                    dispatch.elementMouseover({
+                        label: getX(d.data),
+                        value: getY(d.data),
+                        point: d.data,
+                        pointIndex: i,
+                        pos: [d3.event.pageX, d3.event.pageY],
+                        id: id
+                    });
+                }
               })
               .on('mouseout', function(d,i){
                 d3.select(this).classed('hover', false);
@@ -11176,6 +11178,9 @@ nv.models.scatter = function() {
 
           var mouseEventCallback = function(d,mDispatch) {
                 if (needsUpdate) return 0;
+                
+                if (typeof d == 'undefined') return;
+                
                 var series = data[d.series];
                 if (typeof series === 'undefined') return;
 
@@ -13498,30 +13503,36 @@ nv.models.stackedArea = function() {
           })
           .on('mouseover', function(d,i) {
             d3.select(this).classed('hover', true);
-            dispatch.areaMouseover({
-              point: d,
-              series: d.key,
-              pos: [d3.event.pageX, d3.event.pageY],
-              seriesIndex: d.seriesIndex
-            });
+            if (d3.event) {
+              dispatch.areaMouseover({
+                point: d,
+                series: d.key,
+                pos: [d3.event.pageX, d3.event.pageY],
+                seriesIndex: d.seriesIndex
+              });
+            }
           })
           .on('mouseout', function(d,i) {
             d3.select(this).classed('hover', false);
-            dispatch.areaMouseout({
-              point: d,
-              series: d.key,
-              pos: [d3.event.pageX, d3.event.pageY],
-              seriesIndex: d.seriesIndex
-            });
+            if (d3.event) {
+              dispatch.areaMouseout({
+                point: d,
+                series: d.key,
+                pos: [d3.event.pageX, d3.event.pageY],
+                seriesIndex: d.seriesIndex
+              });
+            }
           })
           .on('click', function(d,i) {
             d3.select(this).classed('hover', false);
-            dispatch.areaClick({
-              point: d,
-              series: d.key,
-              pos: [d3.event.pageX, d3.event.pageY],
-              seriesIndex: d.seriesIndex
-            });
+            if (d3.event) {
+              dispatch.areaClick({
+                point: d,
+                series: d.key,
+                pos: [d3.event.pageX, d3.event.pageY],
+                seriesIndex: d.seriesIndex
+              });
+            }
           })
 
       path.exit().remove();


### PR DESCRIPTION
The ability to position the left label text is there through axisLabelDistance, however the right and bottom labels for a chart do not have this functionality. It has now been added (used the same way for all three)

xAxis.axisLabelDistance...
yAxis.axisLabelDistance...
y1Axis.axisLabelDistance...
y2Axis.axisLabelDistance...

I also came a cross a few errors while dealing with multiple charts on a page where sometimes (not all the time) there would be an error on mouse over of sections of a chart. This was due to the d3.event being undefined and then later it using d3.event.pageX or d3.event.pageY. I threw in checks to see if d3.event was truethy and if so continue on, if not, do nothing.

If you have any questions or comments, please let me know.