### PR TITLE
Made windowResize use addEventListener over window.onresize

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -27,17 +27,22 @@ nv.utils.windowSize = function() {
 
 
 
-// Easy way to bind multiple functions to window.onresize
-// TODO: give a way to remove a function after its bound, other than removing all of them
-nv.utils.windowResize = function(fun){
-  if (fun === undefined) return;
-  var oldresize = window.onresize;
+// Adds a resize listener to the window.
+nv.utils.onWindowResize = function(fun) {
+  if (fun == null) return;
 
-  window.onresize = function(e) {
-    if (typeof oldresize == 'function') oldresize(e);
-    fun(e);
-  }
-}
+  window.addEventListener('resize', fun);
+};
+
+// Backwards compatibility with current API.
+nv.utils.windowResize = nv.utils.onWindowResize;
+
+// Removes a resize listener from the window.
+nv.utils.offWindowResize = function(fun) {
+  if (fun == null) return;
+
+  window.removeEventListener('resize', fun);
+};
 
 // Backwards compatible way to implement more d3-like coloring of graphs.
 // If passed an array, wrap it in a function which implements the old default


### PR DESCRIPTION
With the current implementation, windowResize can only be used to add
an event listener not remove one. You can only remove all listeners by
setting ```window.onresize = null;```

This patch uses ```window.addEventListener(‘resize’, fun);``` instead so an
individual function can be removed when needed.

The basis for this is I'm trying to use nvd3 in a single page app, and would like to ensure event listeners are removed when I navigate to another page to avoid memory leaks.