### PR TITLE
fix highlightZero: Firstly, previously d.__data__ was checked for zeros,...

### DIFF
--- a/nv.d3.css
+++ b/nv.d3.css
@@ -235,6 +235,7 @@ svg .title {
 .nvd3 .nv-axis .zero line,
 /*this selector may not be necessary*/ .nvd3 .nv-axis line.zero {
   stroke-opacity: .75;
+  stroke: #000; /* Color zero-line so that it is distinguishable from the other lines. */
 }
 
 .nvd3 .nv-axis .nv-axisMaxMin text {

--- a/nv.d3.js
+++ b/nv.d3.js
@@ -1314,7 +1314,7 @@ nv.utils.optionsFunc = function(args) {
       //highlight zero line ... Maybe should not be an option and should just be in CSS?
       if (highlightZero)
         g.selectAll('.tick')
-          .filter(function(d) { return !parseFloat(Math.round(d.__data__*100000)/1000000) && (d.__data__ !== undefined) }) //this is because sometimes the 0 tick is a very small fraction, TODO: think of cleaner technique
+          .filter(function(d) { return !parseFloat(Math.round(d*100000)/1000000) && (d !== undefined) }) //this is because sometimes the 0 tick is a very small fraction, TODO: think of cleaner technique
             .classed('zero', true);
 
       //store old scales for use in transitions on update

--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -296,7 +296,7 @@ nv.models.axis = function() {
       //highlight zero line ... Maybe should not be an option and should just be in CSS?
       if (highlightZero)
         g.selectAll('.tick')
-          .filter(function(d) { return !parseFloat(Math.round(d.__data__*100000)/1000000) && (d.__data__ !== undefined) }) //this is because sometimes the 0 tick is a very small fraction, TODO: think of cleaner technique
+          .filter(function(d) { return !parseFloat(Math.round(d*100000)/1000000) && (d !== undefined) }) //this is because sometimes the 0 tick is a very small fraction, TODO: think of cleaner technique
             .classed('zero', true);
 
       //store old scales for use in transitions on update

--- a/src/nv.d3.css
+++ b/src/nv.d3.css
@@ -235,6 +235,7 @@ svg .title {
 .nvd3 .nv-axis .zero line,
 /*this selector may not be necessary*/ .nvd3 .nv-axis line.zero {
   stroke-opacity: .75;
+  stroke: #000; /* Color zero-line so that it is distinguishable from the other lines. */
 }
 
 .nvd3 .nv-axis .nv-axisMaxMin text {


### PR DESCRIPTION
... but the data is actually bound directly to d. Secondly, previously the css just set zeroline opacity higher, but this alone is not sufficient to visually distinguish it from the other lines, hence we explicitly set its color to black.