### PR TITLE
scatterChart and sparklinePlus bug fixes

### DIFF
--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -167,7 +167,7 @@ nv.models.scatterChart = function() {
       var g = wrap.select('g');
 
       // background for pointer events
-      gEnter.append('rect').attr('class', 'nvd3 nv-background');
+      gEnter.append('rect').attr('class', 'nvd3 nv-background').style("pointer-events","none");
 
       gEnter.append('g').attr('class', 'nv-x nv-axis');
       gEnter.append('g').attr('class', 'nv-y nv-axis');

--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -354,6 +354,7 @@ nv.models.scatterChart = function() {
         y.distortion(fisheye).focus(mouse[1]);
 
         g.select('.nv-scatterWrap')
+            .datum(data.filter(function(d) { return !d.disabled }))
             .call(scatter);
 
         if (showXAxis)

--- a/src/models/sparklinePlus.js
+++ b/src/models/sparklinePlus.js
@@ -36,7 +36,7 @@ nv.models.sparklinePlus = function() {
 
       
 
-      chart.update = function() { chart(selection) };
+      chart.update = function() { container.transition().call(chart); };
       chart.container = this;
 
 


### PR DESCRIPTION
I've fixed two bugs in the scatterChart model: data won't filter correctly when you enable fisheye, and pointer-events aren't initialized.

Fiddle http://jsfiddle.net/qggT8/1/ displays those problems and fiddle http://jsfiddle.net/qggT8/3/ has them fixed. Please contact me if you need any further details and thanks for your work.