### PR TITLE
fix multiChart axis classes to match other models

### DIFF
--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -94,9 +94,9 @@ nv.models.multiChart = function() {
       var wrap = container.selectAll('g.wrap.multiChart').data([data]);
       var gEnter = wrap.enter().append('g').attr('class', 'wrap nvd3 multiChart').append('g');
 
-      gEnter.append('g').attr('class', 'x axis');
-      gEnter.append('g').attr('class', 'y1 axis');
-      gEnter.append('g').attr('class', 'y2 axis');
+      gEnter.append('g').attr('class', 'nv-x nv-axis');
+      gEnter.append('g').attr('class', 'nv-y1 nv-axis');
+      gEnter.append('g').attr('class', 'nv-y2 nv-axis');
       gEnter.append('g').attr('class', 'lines1Wrap');
       gEnter.append('g').attr('class', 'lines2Wrap');
       gEnter.append('g').attr('class', 'bars1Wrap');
@@ -226,7 +226,7 @@ nv.models.multiChart = function() {
         .ticks( availableWidth / 100 )
         .tickSize(-availableHeight, 0);
 
-      g.select('.x.axis')
+      g.select('.nv-x.nv-axis')
           .attr('transform', 'translate(0,' + availableHeight + ')');
       d3.transition(g.select('.x.axis'))
           .call(xAxis);
@@ -236,17 +236,17 @@ nv.models.multiChart = function() {
         .tickSize( -availableWidth, 0);
 
 
-      d3.transition(g.select('.y1.axis'))
+      d3.transition(g.select('.nv-y1.nv-axis'))
           .call(yAxis1);
 
       yAxis2
         .ticks( availableHeight / 36 )
         .tickSize( -availableWidth, 0);
 
-      d3.transition(g.select('.y2.axis'))
+      d3.transition(g.select('.nv-y2.nv-axis'))
           .call(yAxis2);
 
-      g.select('.y2.axis')
+      g.select('.nv-y2.nv-axis')
           .style('opacity', series2.length ? 1 : 0)
           .attr('transform', 'translate(' + x.range()[1] + ',0)');
 


### PR DESCRIPTION
Would be nice to rename <code>yAxis1</code>/<code>yAxis2</code> to <code>y1Axis</code>/<code>y2Axis</code> to match linePlusBarChart, altough it's an API change that could break things for some people.

Two maybe a little related questions if you have time:
* what's the the tests status? <code>grunt lint</code> is throwing a lot of red at me but it could be my badly setup env
* are there currently any specific plans on how code could by DRYed a bit? I know it's difficult, especially keeping it simple and easy to dive in, but at least some parts seem to be begging for it.