### PR TITLE
Added text colour  so that tooltips display correctly when on pages with white text.

### DIFF
--- a/src/nv.d3.css
+++ b/src/nv.d3.css
@@ -30,6 +30,7 @@
 .nvtooltip {
   position: absolute;
   background-color: rgba(255,255,255,1.0);
+  color: rgba(0,0,0,1.0);
   padding: 1px;
   border: 1px solid rgba(0,0,0,.2);
   z-index: 10000;
@@ -73,6 +74,7 @@
   line-height: 18px;
   font-weight: normal;
   background-color: rgba(247,247,247,0.75);
+  color: rgba(0,0,0,1.0);
   text-align: center;
 
   border-bottom: 1px solid #ebebeb;


### PR DESCRIPTION
If a chart is displayed on a page with white text, the tool-tips become unreadable. I have added two lines of CSS to ensure that the tool-tip's text is displayed in black so that it can be read.