### PR TITLE
Remove chart when no data is available

### DIFF
--- a/src/models/bulletChart.js
+++ b/src/models/bulletChart.js
@@ -64,6 +64,7 @@ nv.models.bulletChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!d || !ranges.call(this, d, i)) {
+      container.selectAll('g.nv-wrap.nv-bulletChart').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -130,6 +130,7 @@ nv.models.cumulativeLineChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-cumulativeLine').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/discreteBarChart.js
+++ b/src/models/discreteBarChart.js
@@ -83,6 +83,7 @@ nv.models.discreteBarChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-discreteBarWithAxes').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/historicalBarChart.js
+++ b/src/models/historicalBarChart.js
@@ -107,6 +107,7 @@ nv.models.historicalBarChart = function() {
       // Display noData message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-historicalBarChart').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -96,6 +96,7 @@ nv.models.lineChart = function() {
       // Display noData message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-lineChart').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -106,6 +106,7 @@ nv.models.linePlusBarChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        d3.select(this).selectAll('g.nv-wrap.nv-linePlusBar').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/linePlusBarWithFocusChart.js
+++ b/src/models/linePlusBarWithFocusChart.js
@@ -116,6 +116,7 @@ nv.models.linePlusBarWithFocusChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-linePlusBar').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/lineWithFisheyeChart.js
+++ b/src/models/lineWithFisheyeChart.js
@@ -62,6 +62,7 @@ nv.models.lineChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-lineChart').remove();
         container.append('text')
           .attr('class', 'nvd3 nv-noData')
           .attr('x', availableWidth / 2)

--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -95,6 +95,7 @@ nv.models.lineWithFocusChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-lineWithFocusChart').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -105,6 +105,7 @@ nv.models.multiBarChart = function() {
       // Display noData message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-multiBarWithLegend').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -103,6 +103,7 @@ nv.models.multiBarHorizontalChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-multiBarHorizontalChart').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/multiBarTimeSeriesChart.js
+++ b/src/models/multiBarTimeSeriesChart.js
@@ -82,6 +82,7 @@ nv.models.multiBarTimeSeriesChart = function() {
       // Display noData message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-multiBarWithLegend').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -75,6 +75,7 @@ nv.models.pieChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!data || !data.length) {
+        container.selectAll('g.nv-wrap.nv-pieChart').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -129,6 +129,7 @@ nv.models.scatterChart = function() {
       // Display noData message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-scatterChart').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/scatterPlusLineChart.js
+++ b/src/models/scatterPlusLineChart.js
@@ -128,6 +128,7 @@ nv.models.scatterPlusLineChart = function() {
       // Display noData message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-scatterChart').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -101,6 +101,7 @@ nv.models.stackedAreaChart = function() {
       // Display No Data message if there's nothing to show.
 
       if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+        container.selectAll('g.nv-wrap.nv-stackedAreaChart').remove();
         var noDataText = container.selectAll('.nv-noData').data([noData]);
 
         noDataText.enter().append('text')


### PR DESCRIPTION
I'm using nvd3 to visualize real time data, and I've noticed that the chart is not removed when there is no data available.
![nvd3_nodata](https://f.cloud.github.com/assets/200462/2109637/e896fbe4-8ff3-11e3-8510-ea1f6ca80b78.png)
