### PR TITLE
Fixed placement of x axis label

### DIFF
--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -68,6 +68,7 @@ nv.models.axis = function() {
       // scale.range is 1. Difficult to tell.
       var xPosition = scale.range()[0];
     }
+    return xPosition;
   }
 
   function chart(selection) {

--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -39,6 +39,36 @@ nv.models.axis = function() {
 
   //============================================================
 
+  function getXLabelPosition(scale) {
+    // This function calculates the midway position for the X
+    // label. It tries to use rangeExtent() if present. If not, it
+    // defers to range() values. Depending on the chart type, these
+    // can have different meanings and it can be difficult to
+    // calculate the full range of the chart. This should work in all
+    // cases.
+    var xPosition;
+    if ('rangeExtent' in scale) {
+      xPosition = (scale.rangeExtent()[1] + scale.rangeExtent()[0]) / 2;
+      return xPosition;
+    }
+
+    if (scale.range().length > 2) {
+      var w = scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]);
+      xPosition = w / 2;
+    } else if (scale.range().length == 2) {
+      if (scale.range()[0] == 0) {
+	// presumably range is [0, full_length]
+	var xPosition = scale.range()[1] / 2;
+      } else {
+	// use same method as for when there are > 2 points, though simplified
+	var w = scale.range()[1] - (scale.range()[0] / 2);
+	xPosition = w / 2;
+      }
+    } else {
+      // scale.range is 1. Difficult to tell.
+      var xPosition = scale.range()[0];
+    }
+  }
 
   function chart(selection) {
     selection.each(function(data) {
@@ -80,11 +110,10 @@ nv.models.axis = function() {
       switch (axis.orient()) {
         case 'top':
           axisLabel.enter().append('text').attr('class', 'nv-axislabel');
-          var w = (scale.range().length==2) ? scale.range()[1] : (scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]));
           axisLabel
               .attr('text-anchor', 'middle')
               .attr('y', 0)
-              .attr('x', w/2);
+              .attr('x', getXLabelPosition(scale));
           if (showMaxMin) {
             var axisMaxMin = wrap.selectAll('g.nv-axisMaxMin')
                            .data(scale.domain());
@@ -127,11 +156,10 @@ nv.models.axis = function() {
               .style('text-anchor', rotateLabels%360 > 0 ? 'start' : 'end');
           }
           axisLabel.enter().append('text').attr('class', 'nv-axislabel');
-          var w = (scale.range().length==2) ? scale.range()[1] : (scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]));
           axisLabel
               .attr('text-anchor', 'middle')
               .attr('y', xLabelMargin)
-              .attr('x', w/2);
+              .attr('x', getXLabelPosition(scale));
           if (showMaxMin) {
           //if (showMaxMin && !isOrdinal) {
             var axisMaxMin = wrap.selectAll('g.nv-axisMaxMin')


### PR DESCRIPTION
The placement of the x axis label was off when a bar chart with 1 or 2 bars was used. This change adds in a  function to calculate it.

Ideally, `rangeExtent` should be used if present as it gives the most direct values to be used. 
Failing that, the calculation depends on the number of values in `scale.range()` as follows:
* `scale.range().length > 2`: use old method
* `scale.range().length == 2 AND scale.range[0] == 0`: use old method (presumably `scale.range() == [0, full_length]`)
* `scale.range().length == 2 AND scale.range[0] != 0`: use same method as for `scale.range().length > 2`
* `scale.range().length == 1`: use scale.range[0].

I have not found a case where the last two methods would be used (presumably it requires an ordinal data set in which case `scale.rangeExtent` is present). However, I've added it in for security - the old method didn't take into account every possible use scenario and I wanted to avoid the same mistake.