### PR TITLE
delete duplicates from vertices before passing to voronoi

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -221,6 +221,19 @@ nv.models.scatter = function() {
               [width + 10,-10]
           ]);
 
+	  // delete duplicates from vertices - essential assumption for d3.geom.voronoi
+
+	  var epsilon = 1e-6; // d3 uses 1e-6 to determine equivalence.
+	  vertices = vertices.sort(function(a,b){return ((a[0] - b[0]) || (a[1] - b[1]))});
+	  for (var i = 0; i < vertices.length - 1; ) {
+	    if ((Math.abs(vertices[i][0] - vertices[i+1][0]) < epsilon) &&
+		(Math.abs(vertices[i][1] - vertices[i+1][1]) < epsilon)) {
+	      vertices.splice(i+1, 1);
+	    } else {
+	      i++;
+	    }
+	  }
+
           var voronoi = d3.geom.voronoi(vertices).map(function(d, i) {
               return {
                 'data': bounds.clip(d),

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -160,17 +160,14 @@ nv.models.scatter = function() {
         var vertices = d3.merge(data.map(function(group, groupIndex) {
             return group.values
               .map(function(point, pointIndex) {
-                // *Adding noise to make duplicates very unlikely
                 // *Injecting series and point index for reference
-                /* *Adding a 'jitter' to the points, because there's an issue in d3.geom.voronoi.
-                */
                 var pX = getX(point,pointIndex);
                 var pY = getY(point,pointIndex);
 
-                return [x(pX)+ Math.random() * 1e-7,
-                        y(pY)+ Math.random() * 1e-7,
+                return [x(pX),
+                        y(pY),
                         groupIndex,
-                        pointIndex, point]; //temp hack to add noise untill I think of a better way so there are no duplicates
+                        pointIndex, point];
               })
               .filter(function(pointArray, pointIndex) {
                 return pointActive(pointArray[4], pointIndex); // Issue #237.. move filter to after map, so pointIndex is correct!


### PR DESCRIPTION
This fixes the problem where a scatter plot (as well as other types of plots that use scatter, including lines that use scatter to determine the mouse-over areas) generates an error for recent versions of d3 (after about 3.3.7) and where there are overlapping points.

The problem is that `voronoi()` requires the vertices that it's passed to  not contain duplicates. (see: https://github.com/mbostock/d3/wiki/Voronoi-Geom#wiki-_voronoi).

This solves issues #330 and #368/#427. It may be a better fix than the latter as it fixes the underlying cause. I also found cases where 427 did not fix the problem.
