### PR TITLE
Fix: Legend. Make sure legend references most recent data.

### DIFF
--- a/nv.d3.js
+++ b/nv.d3.js
@@ -5091,6 +5091,9 @@ nv.models.indentedTree = function() {
           })
           .on('click', function(d,i) {
             dispatch.legendClick(d,i);
+
+            var data = series.data();
+
             if (updateState) {
                if (radioButtonMode) {
                    //Radio button mode: set every series to disabled,
@@ -5113,6 +5116,9 @@ nv.models.indentedTree = function() {
           })
           .on('dblclick', function(d,i) {
             dispatch.legendDblclick(d,i);
+
+            var data = series.data();
+
             if (updateState) {
                 //the default behavior of NVD3 legends, when double clicking one,
                 // is to set all other series' to false, and make the double clicked series enabled.

--- a/src/models/legend.js
+++ b/src/models/legend.js
@@ -48,6 +48,9 @@ nv.models.legend = function() {
           })
           .on('click', function(d,i) {
             dispatch.legendClick(d,i);
+
+            var data = series.data();
+
             if (updateState) {
                if (radioButtonMode) {
                    //Radio button mode: set every series to disabled,
@@ -70,6 +73,9 @@ nv.models.legend = function() {
           })
           .on('dblclick', function(d,i) {
             dispatch.legendDblclick(d,i);
+
+            var data = series.data();
+
             if (updateState) {
                 //the default behavior of NVD3 legends, when double clicking one,
                 // is to set all other series' to false, and make the double clicked series enabled.


### PR DESCRIPTION
If nvd3 is being used in a way where the same reference to data is not
kept, the legend can break.

The reason for this is event listeners on legend are only added on
enter; since click and dblclick reference the data from a closure, they
always reference the data value captured when the listeners were setup.

This patch does a lookup of data from series instead of referencing the
captured variable. By doing this, we always have the right data
reference.