### PR TITLE
Expose yScale in discreteBarChart model

### DIFF
--- a/src/models/discreteBarChart.js
+++ b/src/models/discreteBarChart.js
@@ -256,7 +256,7 @@ nv.models.discreteBarChart = function() {
   chart.xAxis = xAxis;
   chart.yAxis = yAxis;
 
-  d3.rebind(chart, discretebar, 'x', 'y', 'xDomain', 'yDomain', 'xRange', 'yRange', 'forceX', 'forceY', 'id', 'showValues', 'valueFormat');
+  d3.rebind(chart, discretebar, 'x', 'y', 'yScale', 'xDomain', 'yDomain', 'xRange', 'yRange', 'forceX', 'forceY', 'id', 'showValues', 'valueFormat');
 
   chart.options = nv.utils.optionsFunc.bind(chart);
   


### PR DESCRIPTION
Right now only linear log is set through `discreteBar` inheritance.

What this pull request does is simply add `yScale` to the `discretebar` object, so any `d3.scale` can be used.

![graph using logarithmic scale](https://f.cloud.github.com/assets/37416/2447994/566b24d6-aea0-11e3-8e1a-6cb0b54c5963.png "Logarithmic scale")
