### PR TITLE
Bugfix: Cumulative Line Chart. Indexify needs to use original lines.y() function

### DIFF
--- a/nv.d3.js
+++ b/nv.d3.js
@@ -2655,7 +2655,6 @@ nv.models.cumulativeLineChart = function() {
     , transitionDuration = 250
     , duration = 250
     , noErrorCheck = false  //if set to TRUE, will bypass an error check in the indexify function.
-    , indexifyYGetter = null
     ;
 
   xAxis
@@ -3373,6 +3372,7 @@ nv.models.cumulativeLineChart = function() {
   // Functions
   //------------------------------------------------------------
 
+  var indexifyYGetter = null;
   /* Normalize the data according to an index point. */
   function indexify(idx, data) {
     if (!indexifyYGetter) indexifyYGetter = lines.y();

--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -40,7 +40,6 @@ nv.models.cumulativeLineChart = function() {
     , transitionDuration = 250
     , duration = 250
     , noErrorCheck = false  //if set to TRUE, will bypass an error check in the indexify function.
-    , indexifyYGetter = null
     ;
 
   xAxis
@@ -758,6 +757,7 @@ nv.models.cumulativeLineChart = function() {
   // Functions
   //------------------------------------------------------------
 
+  var indexifyYGetter = null;
   /* Normalize the data according to an index point. */
   function indexify(idx, data) {
     if (!indexifyYGetter) indexifyYGetter = lines.y();


### PR DESCRIPTION
This fixes a bug in Cumulative Line chart.  When chart.update() is called, there is a Javascript error on the page.
