### PR TITLE
Fix legend width bug introduced by 6752bf5c

### DIFF
--- a/src/models/legend.js
+++ b/src/models/legend.js
@@ -109,7 +109,7 @@ nv.models.legend = function() {
               var legendText = d3.select(this).select('text');
               var nodeTextLength;
               try {
-                nodeTextLength = legendText.getComputedTextLength();
+                nodeTextLength = legendText.node().getComputedTextLength();
                 // If the legendText is display:none'd (nodeTextLength == 0), simulate an error so we approximate, instead
                 if(nodeTextLength <= 0) throw Error();
               }


### PR DESCRIPTION
A commit https://github.com/novus/nvd3/commit/6752bf5cc831e69e17572e91c3a8958ede8996aa removes required `.node()`

```
-                nodeTextLength = legendText.node().getComputedTextLength();
+                nodeTextLength = legendText.getComputedTextLength();
```

Due to this, error always occurs and `nv.utils.calcApproxTextWidth(legendText);` is used.

This fix may resolve recent comment on #107
Please take a look.
