### PR TITLE
map attribute 'area' for focus in linesWithFocusChart

### DIFF
--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -392,6 +392,7 @@ nv.models.lineWithFocusChart = function() {
                 .map(function(d,i) {
                   return {
                     key: d.key,
+                    area: d.area,
                     values: d.values.filter(function(d,i) {
                       return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
                     })


### PR DESCRIPTION
Data series stripped 'area' attribute in onBrush event handler. 
