### PR TITLE
Pie chart: formatting value

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -237,7 +237,7 @@ nv.models.pie = function() {
                   var percent = (d.endAngle - d.startAngle) / (2 * Math.PI);
                   var labelTypes = {
                     "key" : getX(d.data),
-                    "value": getY(d.data),
+                    "value": valueFormat(getY(d.data)),
                     "percent": labelFormat(percent)
                   };
                   return (d.value && percent > labelThreshold) ? labelTypes[labelType] : '';


### PR DESCRIPTION
`value` should be formatted when used as label for segments.