### PR TITLE
fix issue with pointPaths choking on undefined points after voronoi clip...

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -237,7 +237,7 @@ nv.models.scatter = function() {
           pointPaths.exit().remove();
           pointPaths
               .attr('d', function(d) {
-                if (d.data.length === 0)
+                if (!d || !d.data || d.data.length === 0)
                     return 'M 0 0'
                 else
                     return 'M' + d.data.join('L') + 'Z';


### PR DESCRIPTION
Voronoi can clip points out, causing it to return undefined. When the output from voronoi is passed to d3 pointPaths, an undefined value causes an uncaught error to be thrown. The fix just returns M 0 0 for the undefined point.