### PR TITLE
Fixes x axis label position (v2.0.0-dev)

### DIFF
--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -66,6 +66,38 @@ Axis.prototype.draw = function(data){
         scale = this.scale(),
         w = null;
 
+    function getXLabelPosition(scale) {
+	// This function calculates the midway position for the X
+	// label. It tries to use rangeExtent() if present. If not, it
+	// defers to range() values. Depending on the chart type, these
+	// can have different meanings and it can be difficult to
+	// calculate the full range of the chart. This should work in all
+	// cases.
+	var xPosition;
+	if ('rangeExtent' in scale) {
+	    xPosition = (scale.rangeExtent()[1] + scale.rangeExtent()[0]) / 2;
+	    return xPosition;
+	}
+
+	if (scale.range().length > 2) {
+	    var w = scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]);
+	    xPosition = w / 2;
+	} else if (scale.range().length == 2) {
+	    if (scale.range()[0] == 0) {
+		// presumably range is [0, full_length]
+		var xPosition = scale.range()[1] / 2;
+	    } else {
+		// use same method as for when there are > 2 points, though simplified
+		var w = scale.range()[1] - (scale.range()[0] / 2);
+		xPosition = w / 2;
+	    }
+	} else {
+	    // scale.range is 1. Difficult to tell.
+	    var xPosition = scale.range()[0];
+	}
+	return xPosition;
+    }
+
     if (this.ticks() !== null)
         this.axis.ticks(this.ticks());
     else if (this.axis.orient() == 'top' || this.axis.orient() == 'bottom')
@@ -90,13 +122,10 @@ Axis.prototype.draw = function(data){
         case 'top':
             axisLabel.enter().append('text')
                 .attr('class', 'nv-axislabel');
-            w = (scale.range().length==2)
-                ? scale.range()[1]
-                : (scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]));
             axisLabel
                 .attr('text-anchor', 'middle')
                 .attr('y', 0)
-                .attr('x', w/2);
+                .attr('x', getXLabelPosition(scale));
             if (this.showMaxMin()) {
                 axisMaxMin = this.wrap.selectAll('g.nv-axisMaxMin')
                     .data(scale.domain());
@@ -141,13 +170,10 @@ Axis.prototype.draw = function(data){
                     .style('text-anchor', that.rotateLabels()%360 > 0 ? 'start' : 'end');
             }
             axisLabel.enter().append('text').attr('class', 'nv-axislabel');
-            w = (scale.range().length==2)
-                ? scale.range()[1]
-                : (scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]));
             axisLabel
                 .attr('text-anchor', 'middle')
                 .attr('y', xLabelMargin)
-                .attr('x', w/2);
+                .attr('x', getXLabelPosition(scale));
             if (this.showMaxMin()) {
                 //if (showMaxMin && !isOrdinal) {
                 axisMaxMin = this.wrap.selectAll('g.nv-axisMaxMin')
@@ -393,4 +419,3 @@ nv.models.axis = function() {
 
     return chart;
 };
-


### PR DESCRIPTION
This is a rebased version of #447.

Formerly, when there was (eg) a bar chart with just 1 or 2 bars then the position was wrong. The reason for this is that scale.range[0] was the position of the first bar, and scale.range[1] the position of the 2nd. The label was being placed at scale.range[1]/2 which was about 1/4 to 1/3 through the graph.

The new version works as follows:
* If there is `scale.rangeExtent` (ie: the scale is ordinal [not continuous], eg: bar chart) then rangeExtent contains the upper and lower values of the range. we use this to calculate the mid point.
* If not, then if there are more than 2 points, we use the same method as previous - take the highest point, add one more interval (distance between consecutive scale points), and find the half way point between here and the start
* if there are only two points and the first one is zero, go half way between them.
* if there are only two points and the first one is not zero, then use the same method as if there are multiple points.
* if there is only one point, then use that.