### PR TITLE
New chart type «Exploded Pie» declaration

### DIFF
--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -22,6 +22,7 @@ nv.models.pieChart = function() {
     , defaultState = null
     , noData = "No Data Available."
     , dispatch = d3.dispatch('tooltipShow', 'tooltipHide', 'stateChange', 'changeState')
+    , explodeMultiplier = false
     ;
 
   //============================================================
@@ -104,6 +105,14 @@ nv.models.pieChart = function() {
 
       gEnter.append('g').attr('class', 'nv-pieWrap');
       gEnter.append('g').attr('class', 'nv-legendWrap');
+
+      //------------------------------------------------------------
+
+
+      //------------------------------------------------------------
+      // Exploded Pie
+      if (explodeMultiplier)
+          pie.explodeMultiplier(explodeMultiplier);
 
       //------------------------------------------------------------
 
@@ -285,6 +294,11 @@ nv.models.pieChart = function() {
     return chart;
   };
 
+  chart.explodeMultiplier = function(_) {
+    if(!arguments.length) return explodeMultiplier;
+    explodeMultiplier = _;
+    return chart;
+  };
   //============================================================
 
 


### PR DESCRIPTION
This patch extends "Pie Chart" in order to get new chart type "Exploded pie" abillity.
Exploded Pie example
![exploded pie](https://cloud.githubusercontent.com/assets/1282724/3371760/abea29ba-fba4-11e3-9a04-ccd40e1f5b5f.png)
