### PR TITLE
Bottom oriented axis aware of axisLabelDistance

### DIFF
--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -126,7 +126,7 @@ Axis.prototype.draw = function(data){
             }
             break;
         case 'bottom':
-            xLabelMargin = 36;
+            xLabelMargin = axisLabelDistance ? axisLabelDistance + 24 : 36;
             var maxTextWidth = 30;
             var xTicks = this.g.selectAll('g').select("text");
             if (this.rotateLabels()%360) {


### PR DESCRIPTION
axisLabelDistance was only being taken into account for left-oriented axes. This makes bottom-oriented axes aware of it so you can control the vertical positioning axis label.