### PR TITLE
Remove NPE in scatter.js updateInteractiveLayer()

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -237,7 +237,7 @@ nv.models.scatter = function() {
           pointPaths.exit().remove();
           pointPaths
               .attr('d', function(d) {
-                if (d.data.length === 0)
+                if (d === undefined || d.data.length === 0)
                     return 'M 0 0'
                 else
                     return 'M' + d.data.join('L') + 'Z';


### PR DESCRIPTION
It appears that there may not be data associated with certain pointpaths which cause an NPE when attempting to get the length of the data.