### PR TITLE
Add ()'s so that instanceof check works as intended

### DIFF
--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -212,7 +212,7 @@ Has the following known issues:
 */
 nv.interactiveBisect = function (values, searchVal, xAccessor) {
 	  "use strict";
-      if (! values instanceof Array) return null;
+      if (!(values instanceof Array)) return null;
       if (typeof xAccessor !== 'function') xAccessor = function(d,i) { return d.x;}
 
       var bisect = d3.bisector(xAccessor).left;


### PR DESCRIPTION
instanceof has a higher precedence than the ! operator, so this is needed, otherwise you're just calling 'true instanceof Array' or 'false instanceof Array' which are both always false.