### PR TITLE
Missed getX and getY declarations in multiChart

### DIFF
--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -17,7 +17,9 @@ nv.models.multiChart = function() {
       x,
       y,
       yDomain1,
-      yDomain2
+      yDomain2,
+      getX = function(d) { return d.x },
+      getY = function(d) { return d.y }
       ; //can be accessed via chart.lines.[x/y]Scale()
 
   //============================================================


### PR DESCRIPTION
Added the missed getX and getY declarations to avoid errors during the minification process in production environment