### PR TITLE
New mode for multiBarChart called "stacked normalized" with 0-100% domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,97 @@
-# Novus/nvd3 fork for normalized stacked bar charts
+# MAJOR REFACTOR
 
-This fork of NVD3 1.1.15-beta implements a new mode for multiBarChart called "stacked normalized". It displays bars in stacked format
-but normalized values from 0-100%.
+As of mid April, 2014, NVD3 is undergoing a major internal refactoring. While we wanted to make it in such a way that it would be a perfectly backwards compatible minor version release, we cannot do so. There are a half-dozen side and corner cases in the current code base, that, while we could call them "bugs", are just poorly implemented features. Because of this, we are announcing heavy development on the 2.0 NVD3 line, which will bring a sane internal structure and numerous API and development enhancements.
 
-## Modified files:
-* models/multiBarChart.js
-* models/multiBar.js
-* test/multiBarChartTest.html (added new chart 8)
+The code is on the branch at [refactor/2.0.0-dev](https://github.com/novus/nvd3/tree/refactor/2.0.0-dev). It is currently about 4/5ths functional, and we are working through finishing the tests for the last few parameters. The commonly used charts are there, and any outstanding or new pull requests will need to rebase and target that. Of course, if you want to implement some of those features, that would also be great!
 
-## Examples:
-* examples/multiBarChartNorm.html
+For more information on the refactored architecture and approach, please see the recent blog posts on  [architecture](http://nvd3.org/blog/2014/03/architecture/) and [chart drawing lifecycle](http://nvd3.org/blog/2014/03/nvd3-chart-drawing-lifecycle/).
 
-## Notes/Limitations:
-For backward compatibility reasons to old multiCharts the new feature is only enabled if "allowNormalized" is passed to the chart
-during construction.
-The current version technically works (meaning it does not crash) with negative values but the output is mainly crap.
-In order to keep modifications as small as possible the chart function in multiBar.js now internally works on a deep copy of the
-original data. Normalization will then modify the actual values of that copied data to to 0.0-1.0 domain. All other logic and access 
-to variables did not need modification.
-The chart.state() function in multiBarChart.js will now always dispatch a changeState event if a new state is passed in.
+For now, any users of NVD3 still get 1.1.15-beta.
+
+# NVD3 - v1.1.15-beta
+## Release notes for version 1.1.15 beta
+* Various fixes across the board
+
+## Overview
+A reusable chart library for d3.js.
+
+NVD3 may change from its current state, but will always try to follow the style of d3.js.
+
+You can also check out the [examples page](http://nvd3.org/ghpages/examples.html).
+**Note:** The examples on nvd3.org are outdated.  For examples on how to use the latest NVD3, please checkout the **examples/** directory in the repository.
+
+---
+
+# Current development focus
+
+- Getting documentation up.
+- Unifying common API functions between charts.
+- Bug fixes that come up.
+
+---
+
+# Installation Instructions
+
+`d3.v3.js` is a dependency of `nv.d3.js`. Be sure to include in in your project, then:
+Add a script tag to include `nv.d3.js` OR `nv.d3.min.js` in your project.
+Also add a link to the `nv.d3.css` file.
+
+See wiki -> Documentation for more detail
+
+---
+
+If one of [the existing models](https://github.com/novus/nvd3/tree/master/src/models) doesn't meet your needs, fork the project, implement the model and an example using it, send us a pull request, for consideration for inclusion in the project.
+
+We cannot honor all pull requests, but we will review all of them.
+
+Please do not aggregate pull requests. Aggregated pull requests are actually more difficult to review.
+
+We are currently changing our branch structure so that master will be gauranteed stable. In addition, there is now a "development" branch. This branch reflects the latest changes to NVD3 and is not necessarily stable.
+
+---
+
+## Minifying your fork:
+
+### Using Make
+The Makefile requires [UglifyJS](https://github.com/mishoo/UglifyJS) and [CSSMin](https://github.com/jbleuzen/node-cssmin)
+
+The easiest way to install UglifyJS and CSSMin is via npm. Run `npm install -g uglify-js cssmin`. After installing verify the setup by running `uglifyjs --version` and `cssmin --help`.
+
+Once you have the `uglifyjs` and `cssmin` commands available, running `make` from your
+fork's root directory will rebuild both `nv.d3.js` and `nv.d3.min.js`.
+
+    make # build nv.d3.js and nv.d3.css and minify
+    make nv.d3.js # Build nv.d3.js
+    make nv.d3.min.js # Minify nv.d3.js into nv.d3.min.js
+    make nv.d3.css # Build nv.d3.css
+    make nv.d3.min.css # Minify nv.d3.css into nv.d3.min.css
+    make clean # Delete nv.d3.*js and nv.d3.*css
+
+
+*Without UglifyJS or CSSMin, you won't get the minified versions when running make.**
+
+### Using Grunt
+
+You can use grunt instead of makefile to build js file. See more about [grunt](http://gruntjs.com/).
+***[Nodejs](http://nodejs.org/) must be installed before you can use grunt.***
+Run `npm install` in root dir to install grunt and it's dependencies.
+
+Then, you can use these commands:
+
+    grunt # build nv.d3.js
+    grunt production # build nv.d3.js and nv.d3.min.js
+    grunt watch # watch file changes in src/, and rebuild nv.d3.js, it's very helpful when delevop NVD3
+    grunt lint # run jshint on src/**/*.js
+
+**We ask that you DO NOT minify pull requests...
+If you need to minify please build pull request in separate branch, and
+merge and minify in your master.
+
+## Supported Browsers
+NVD3 runs best on WebKit based browsers.
+
+* **Google Chrome: latest version (preferred)**
+* **Opera 15+ (preferred)**
+* Safari: latest version
+* Firefox: latest version
+* Internet Explorer: 9 and 10

--- a/README.md
+++ b/README.md
@@ -1,97 +1,21 @@
-# MAJOR REFACTOR
+# Novus/nvd3 fork for normalized stacked bar charts
 
-As of mid April, 2014, NVD3 is undergoing a major internal refactoring. While we wanted to make it in such a way that it would be a perfectly backwards compatible minor version release, we cannot do so. There are a half-dozen side and corner cases in the current code base, that, while we could call them "bugs", are just poorly implemented features. Because of this, we are announcing heavy development on the 2.0 NVD3 line, which will bring a sane internal structure and numerous API and development enhancements.
+This fork of NVD3 1.1.15-beta implements a new mode for multiBarChart called "stacked normalized". It displays bars in stacked format
+but normalized values from 0-100%.
 
-The code is on the branch at [refactor/2.0.0-dev](https://github.com/novus/nvd3/tree/refactor/2.0.0-dev). It is currently about 4/5ths functional, and we are working through finishing the tests for the last few parameters. The commonly used charts are there, and any outstanding or new pull requests will need to rebase and target that. Of course, if you want to implement some of those features, that would also be great!
+## Modified files:
+* models/multiBarChart.js
+* models/multiBar.js
+* test/multiBarChartTest.html (added new chart 8)
 
-For more information on the refactored architecture and approach, please see the recent blog posts on  [architecture](http://nvd3.org/blog/2014/03/architecture/) and [chart drawing lifecycle](http://nvd3.org/blog/2014/03/nvd3-chart-drawing-lifecycle/).
+## Examples:
+* examples/multiBarChartNorm.html
 
-For now, any users of NVD3 still get 1.1.15-beta.
-
-# NVD3 - v1.1.15-beta
-## Release notes for version 1.1.15 beta
-* Various fixes across the board
-
-## Overview
-A reusable chart library for d3.js.
-
-NVD3 may change from its current state, but will always try to follow the style of d3.js.
-
-You can also check out the [examples page](http://nvd3.org/ghpages/examples.html).
-**Note:** The examples on nvd3.org are outdated.  For examples on how to use the latest NVD3, please checkout the **examples/** directory in the repository.
-
----
-
-# Current development focus
-
-- Getting documentation up.
-- Unifying common API functions between charts.
-- Bug fixes that come up.
-
----
-
-# Installation Instructions
-
-`d3.v3.js` is a dependency of `nv.d3.js`. Be sure to include in in your project, then:
-Add a script tag to include `nv.d3.js` OR `nv.d3.min.js` in your project.
-Also add a link to the `nv.d3.css` file.
-
-See wiki -> Documentation for more detail
-
----
-
-If one of [the existing models](https://github.com/novus/nvd3/tree/master/src/models) doesn't meet your needs, fork the project, implement the model and an example using it, send us a pull request, for consideration for inclusion in the project.
-
-We cannot honor all pull requests, but we will review all of them.
-
-Please do not aggregate pull requests. Aggregated pull requests are actually more difficult to review.
-
-We are currently changing our branch structure so that master will be gauranteed stable. In addition, there is now a "development" branch. This branch reflects the latest changes to NVD3 and is not necessarily stable.
-
----
-
-## Minifying your fork:
-
-### Using Make
-The Makefile requires [UglifyJS](https://github.com/mishoo/UglifyJS) and [CSSMin](https://github.com/jbleuzen/node-cssmin)
-
-The easiest way to install UglifyJS and CSSMin is via npm. Run `npm install -g uglify-js cssmin`. After installing verify the setup by running `uglifyjs --version` and `cssmin --help`.
-
-Once you have the `uglifyjs` and `cssmin` commands available, running `make` from your
-fork's root directory will rebuild both `nv.d3.js` and `nv.d3.min.js`.
-
-    make # build nv.d3.js and nv.d3.css and minify
-    make nv.d3.js # Build nv.d3.js
-    make nv.d3.min.js # Minify nv.d3.js into nv.d3.min.js
-    make nv.d3.css # Build nv.d3.css
-    make nv.d3.min.css # Minify nv.d3.css into nv.d3.min.css
-    make clean # Delete nv.d3.*js and nv.d3.*css
-
-
-*Without UglifyJS or CSSMin, you won't get the minified versions when running make.**
-
-### Using Grunt
-
-You can use grunt instead of makefile to build js file. See more about [grunt](http://gruntjs.com/).
-***[Nodejs](http://nodejs.org/) must be installed before you can use grunt.***
-Run `npm install` in root dir to install grunt and it's dependencies.
-
-Then, you can use these commands:
-
-    grunt # build nv.d3.js
-    grunt production # build nv.d3.js and nv.d3.min.js
-    grunt watch # watch file changes in src/, and rebuild nv.d3.js, it's very helpful when delevop NVD3
-    grunt lint # run jshint on src/**/*.js
-
-**We ask that you DO NOT minify pull requests...
-If you need to minify please build pull request in separate branch, and
-merge and minify in your master.
-
-## Supported Browsers
-NVD3 runs best on WebKit based browsers.
-
-* **Google Chrome: latest version (preferred)**
-* **Opera 15+ (preferred)**
-* Safari: latest version
-* Firefox: latest version
-* Internet Explorer: 9 and 10
+## Notes/Limitations:
+For backward compatibility reasons to old multiCharts the new feature is only enabled if "allowNormalized" is passed to the chart
+during construction.
+The current version technically works (meaning it does not crash) with negative values but the output is mainly crap.
+In order to keep modifications as small as possible the chart function in multiBar.js now internally works on a deep copy of the
+original data. Normalization will then modify the actual values of that copied data to to 0.0-1.0 domain. All other logic and access 
+to variables did not need modification.
+The chart.state() function in multiBarChart.js will now always dispatch a changeState event if a new state is passed in.

--- a/examples/multiBarChartNorm.html
+++ b/examples/multiBarChartNorm.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<link href="../src/nv.d3.css" rel="stylesheet" type="text/css">
+
+<style>
+
+body {
+  overflow-y:scroll;
+}
+
+text {
+  font: 12px sans-serif;
+}
+
+#chart1 {
+  height: 500px;
+  margin: 10px;
+  min-width: 100px;
+  min-height: 100px;
+/*
+  Minimum height and width is a good idea to prevent negative SVG dimensions...
+  For example width should be =< margin.left + margin.right + 1,
+  of course 1 pixel for the entire chart would not be very useful, BUT should not have errors
+*/
+}
+
+</style>
+<body>
+
+  <div id="chart1" class='with-3d-shadow with-transitions'>
+    <svg></svg>
+  </div>
+  
+
+<script src="../lib/d3.v3.js"></script>
+<script src="../nv.d3.js"></script>
+<script src="../src/tooltip.js"></script>
+<script src="../src/utils.js"></script>
+<script src="../src/models/legend.js"></script>
+<script src="../src/models/axis.js"></script>
+<script src="../src/models/multiBar.js"></script>
+<script src="../src/models/multiBarChart.js"></script>
+<script src="stream_layers.js"></script>
+<script>
+
+var test_data = stream_layers(3,10+Math.random()*100,.1).map(function(data, i) {
+//var test_data = stream_layers(3,1,.1).map(function(data, i) { //for testing single data point
+  return {
+    key: 'Stream' + i,
+    values: data
+  };
+});
+
+console.log('td',test_data);
+
+var non_negative_test_data = new d3.range(0,3).map(function(d,i) { return {
+  key: 'Stream' + i,
+  values: new d3.range(0,11).map( function(f,j) {
+    return { 
+             y: 10 + Math.random()*100 * (Math.floor(Math.random()*100)%2 ? 1 : 1),
+             x: j
+           }
+  })
+  };  
+});
+
+var chart;
+nv.addGraph(function() {
+    chart = nv.models.multiBarChart()
+      .barColor(d3.scale.category20().range())
+      .margin({bottom: 100})
+      .transitionDuration(300)
+      .delay(0)
+      .rotateLabels(45)
+      .groupSpacing(0.1)
+      .allowNormalized(true)
+      ;
+
+    chart.multibar
+      .hideable(true);
+
+    chart.reduceXTicks(false).staggerLabels(true);
+
+    chart.xAxis
+        .axisLabel("Current Index")
+        .showMaxMin(true)
+        .tickFormat(d3.format(',.6f'));
+
+    chart.yAxis
+        .tickFormat(d3.format(',.1f'));
+
+    d3.select('#chart1 svg')
+        .datum(non_negative_test_data)
+       .call(chart);
+
+    nv.utils.windowResize(chart.update);
+
+    chart.dispatch.on('stateChange', function(e) { nv.log('New State:', JSON.stringify(e)); 
+       
+    
+    });
+
+    return chart;
+});
+
+
+
+
+</script>

--- a/nv.d3.js
+++ b/nv.d3.js
@@ -4650,8 +4650,7 @@ nv.models.indentedTree = function() {
 
             d3.select(this).select('span')
               .attr('class', d3.functor(column.classes) )
-              .text(function(d) { return column.format ? column.format(d) :
-                                        (d[column.key] || '-') });
+              .text(function(d) { return column.format ? (d[column.key] ? column.format(d[column.key]) : '-') :  (d[column.key] || '-'); });
           });
 
         if  (column.showCount) {
@@ -4959,7 +4958,7 @@ nv.models.indentedTree = function() {
               var legendText = d3.select(this).select('text');
               var nodeTextLength;
               try {
-                nodeTextLength = legendText.node().getComputedTextLength();
+                nodeTextLength = legendText.getComputedTextLength();
                 // If the legendText is display:none'd (nodeTextLength == 0), simulate an error so we approximate, instead
                 if(nodeTextLength <= 0) throw Error();
               }
@@ -6688,7 +6687,6 @@ nv.models.lineWithFocusChart = function() {
                 .map(function(d,i) {
                   return {
                     key: d.key,
-                    area: d.area,
                     values: d.values.filter(function(d,i) {
                       return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
                     })
@@ -7557,7 +7555,6 @@ nv.models.multiBar = function() {
     , yRange
     , groupSpacing = 0.1
     , dispatch = d3.dispatch('chartClick', 'elementClick', 'elementDblClick', 'elementMouseover', 'elementMouseout')
-    , normalized = false
     ;
 
   //============================================================
@@ -7578,7 +7575,7 @@ nv.models.multiBar = function() {
       var availableWidth = width - margin.left - margin.right,
           availableHeight = height - margin.top - margin.bottom,
           container = d3.select(this);
-      
+
       if(hideable && data.length) hideable = [{
         values: data[0].values.map(function(d) {
         return {
@@ -7588,24 +7585,7 @@ nv.models.multiBar = function() {
           size: 0.01
         };}
       )}];
-      // internal copy so that org data is NEVER modified.
-      // necessary since we are calculating new y values for normalized state
-      
-      var data = JSON.parse(JSON.stringify(data));
-      if (normalized && data.length>0) {
-          data[0].values.forEach(function(val,i){
-              var values = [];
-              for (var c=0;c<data.length;c++){
-                  values.push(data[c].values[i].y);
-              }
-              var sum = d3.sum(values);
-              
-              data.forEach(function(d){
-                  d.values[i].y = sum>0 ? d.values[i].y/sum :0;
-              });
-          });
-      }
-      
+
       if (stacked)
         data = d3.layout.stack()
                  .offset(stackOffset)
@@ -7620,7 +7600,8 @@ nv.models.multiBar = function() {
           point.series = i;
         });
       });
-      
+
+
       //------------------------------------------------------------
       // HACK for negative value stacking
       if (stacked)
@@ -7647,7 +7628,7 @@ nv.models.multiBar = function() {
       var seriesData = (xDomain && yDomain) ? [] : // if we know xDomain and yDomain, no need to calculate
             data.map(function(d) {
               return d.values.map(function(d,i) {
-                return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1}
+                return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1 }
               })
             });
 
@@ -7655,10 +7636,7 @@ nv.models.multiBar = function() {
           .rangeBands(xRange || [0, availableWidth], groupSpacing);
 
       //y   .domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { return d.y + (stacked ? d.y1 : 0) }).concat(forceY)))
-      y   .domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { 
-            return stacked ? (getY(d) > 0 ? d.y1 : d.y1 + getY(d) ) : getY(d) 
-            })
-          .concat(forceY)))
+      y   .domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { return stacked ? (d.y > 0 ? d.y1 : d.y1 + d.y ) : d.y }).concat(forceY)))
           .range(yRange || [availableHeight, 0]);
 
       // If scale's domain don't have a range, slightly adjust to make one... so a chart can show a single data point
@@ -8003,12 +7981,6 @@ nv.models.multiBar = function() {
     return chart;
   };
 
-
-chart.normalized = function(_) {
-    if (!arguments.length) return normalized;
-    normalized = _;
-    return chart;
-  };
   //============================================================
 
 
@@ -8051,11 +8023,8 @@ nv.models.multiBarChart = function() {
     , defaultState = null
     , noData = "No Data Available."
     , dispatch = d3.dispatch('tooltipShow', 'tooltipHide', 'stateChange', 'changeState')
-    , controlWidth = function() { return showControls ? (allowNormalized? 290 : 180) : 0 }
+    , controlWidth = function() { return showControls ? 180 : 0 }
     , transitionDuration = 250
-    // new stuff from pschoepf
-    , orgYTickFormat = null // used to store original tick format before switching to normalized % view
-    , allowNormalized = false // enables control for normalized stacked
     ;
 
   multibar
@@ -8072,7 +8041,7 @@ nv.models.multiBarChart = function() {
     .orient((rightAlignYAxis) ? 'right' : 'left')
     .tickFormat(d3.format(',.1f'))
     ;
-  
+
   controls.updateState(false);
   //============================================================
 
@@ -8201,16 +8170,10 @@ nv.models.multiBarChart = function() {
       // Controls
 
       if (showControls) {
-         var controlsData = [
+        var controlsData = [
           { key: 'Grouped', disabled: multibar.stacked() },
-          { key: 'Stacked', disabled: !multibar.stacked() || (multibar.stacked()&& multibar.normalized())}
-           
+          { key: 'Stacked', disabled: !multibar.stacked() }
         ];
-        // add normalized 100% control switch if enabled by property
-        if (allowNormalized) {
-           controlsData.push({ key: 'Stacked normalized', disabled: !multibar.stacked() ||(multibar.stacked() && !multibar.normalized()) });
-        }
-        
 
         controls.width(controlWidth()).color(['#444', '#444', '#444']);
         g.select('.nv-controlsWrap')
@@ -8330,7 +8293,6 @@ nv.models.multiBarChart = function() {
       legend.dispatch.on('stateChange', function(newState) { 
         state = newState;
         dispatch.stateChange(state);
-        
         chart.update();
       });
 
@@ -8345,29 +8307,13 @@ nv.models.multiBarChart = function() {
         switch (d.key) {
           case 'Grouped':
             multibar.stacked(false);
-            multibar.normalized(false);
             break;
           case 'Stacked':
             multibar.stacked(true);
-            multibar.normalized(false);
-            break;
-          case 'Stacked normalized':
-            multibar.stacked(true);
-            multibar.normalized(true);
             break;
         }
 
         state.stacked = multibar.stacked();
-        state.normalized = multibar.normalized();
-        if (multibar.normalized()) {
-            orgYTickFormat = yAxis.tickFormat();
-            yAxis
-            .tickFormat(d3.format('.0%'))
-        } else if (orgYTickFormat) {
-            yAxis
-            .tickFormat(orgYTickFormat)
-        }
-        
         dispatch.stateChange(state);
 
         chart.update();
@@ -8390,10 +8336,7 @@ nv.models.multiBarChart = function() {
 
         if (typeof e.stacked !== 'undefined') {
           multibar.stacked(e.stacked);
-          multibar.normalized(e.normalized);
           state.stacked = e.stacked;
-          state.normalized = e.normalized;
-          
         }
 
         chart.update();
@@ -8439,7 +8382,7 @@ nv.models.multiBarChart = function() {
   chart.yAxis = yAxis;
 
   d3.rebind(chart, multibar, 'x', 'y', 'xDomain', 'yDomain', 'xRange', 'yRange', 'forceX', 'forceY', 'clipEdge',
-   'id', 'stacked', 'stackOffset', 'delay', 'barColor','groupSpacing','normalized');
+   'id', 'stacked', 'stackOffset', 'delay', 'barColor','groupSpacing');
 
   chart.options = nv.utils.optionsFunc.bind(chart);
   
@@ -8541,7 +8484,6 @@ nv.models.multiBarChart = function() {
   chart.state = function(_) {
     if (!arguments.length) return state;
     state = _;
-    dispatch.changeState(_);
     return chart;
   };
 
@@ -8563,11 +8505,6 @@ nv.models.multiBarChart = function() {
     return chart;
   };
 
-  chart.allowNormalized = function(_) {
-    if (!arguments.length) return allowNormalized;
-    allowNormalized = _;
-    return chart;
-  };
   //============================================================
 
 
@@ -10328,7 +10265,6 @@ nv.models.pie = function() {
     , id = Math.floor(Math.random() * 10000) //Create semi-unique ID in case user doesn't select one
     , color = nv.utils.defaultColor()
     , valueFormat = d3.format(',.2f')
-    , labelFormat = d3.format('%')
     , showLabels = true
     , pieLabelsOutside = true
     , donutLabelsOutside = false
@@ -10536,13 +10472,11 @@ nv.models.pie = function() {
                       Adjust the label's y-position to remove the overlap.
                       */
                       var center = labelsArc.centroid(d);
-                      if(d.value){
-                        var hashKey = createHashKey(center);
-                        if (labelLocationHash[hashKey]) {
-                          center[1] -= avgHeight;
-                        }
-                        labelLocationHash[createHashKey(center)] = true;
+                      var hashKey = createHashKey(center);
+                      if (labelLocationHash[hashKey]) {
+                        center[1] -= avgHeight;
                       }
+                      labelLocationHash[createHashKey(center)] = true;
                       return 'translate(' + center + ')'
                     }
                 });
@@ -10553,7 +10487,7 @@ nv.models.pie = function() {
                   var labelTypes = {
                     "key" : getX(d.data),
                     "value": getY(d.data),
-                    "percent": labelFormat(percent)
+                    "percent": d3.format('%')(percent)
                   };
                   return (d.value && percent > labelThreshold) ? labelTypes[labelType] : '';
                 });
@@ -10712,12 +10646,6 @@ nv.models.pie = function() {
   chart.valueFormat = function(_) {
     if (!arguments.length) return valueFormat;
     valueFormat = _;
-    return chart;
-  };
-
-  chart.labelFormat = function(_) {
-    if (!arguments.length) return labelFormat;
-    labelFormat = _;
     return chart;
   };
 
@@ -10950,9 +10878,9 @@ nv.models.pieChart = function() {
   chart.dispatch = dispatch;
   chart.pie = pie;
 
-  d3.rebind(chart, pie, 'valueFormat', 'labelFormat', 'values', 'x', 'y', 'description', 'id', 'showLabels', 'donutLabelsOutside', 'pieLabelsOutside', 'labelType', 'donut', 'donutRatio', 'labelThreshold');
+  d3.rebind(chart, pie, 'valueFormat', 'values', 'x', 'y', 'description', 'id', 'showLabels', 'donutLabelsOutside', 'pieLabelsOutside', 'labelType', 'donut', 'donutRatio', 'labelThreshold');
   chart.options = nv.utils.optionsFunc.bind(chart);
-
+  
   chart.margin = function(_) {
     if (!arguments.length) return margin;
     margin.top    = typeof _.top    != 'undefined' ? _.top    : margin.top;

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -28,6 +28,7 @@ nv.models.multiBar = function() {
     , yRange
     , groupSpacing = 0.1
     , dispatch = d3.dispatch('chartClick', 'elementClick', 'elementDblClick', 'elementMouseover', 'elementMouseout')
+    , normalized = false
     ;
 
   //============================================================
@@ -48,7 +49,7 @@ nv.models.multiBar = function() {
       var availableWidth = width - margin.left - margin.right,
           availableHeight = height - margin.top - margin.bottom,
           container = d3.select(this);
-
+      
       if(hideable && data.length) hideable = [{
         values: data[0].values.map(function(d) {
         return {
@@ -58,7 +59,24 @@ nv.models.multiBar = function() {
           size: 0.01
         };}
       )}];
-
+      // internal copy so that org data is NEVER modified.
+      // necessary since we are calculating new y values for normalized state
+      
+      var data = JSON.parse(JSON.stringify(data));
+      if (normalized && data.length>0) {
+          data[0].values.forEach(function(val,i){
+              var values = [];
+              for (var c=0;c<data.length;c++){
+                  values.push(data[c].values[i].y);
+              }
+              var sum = d3.sum(values);
+              
+              data.forEach(function(d){
+                  d.values[i].y = sum>0 ? d.values[i].y/sum :0;
+              });
+          });
+      }
+      
       if (stacked)
         data = d3.layout.stack()
                  .offset(stackOffset)
@@ -73,8 +91,7 @@ nv.models.multiBar = function() {
           point.series = i;
         });
       });
-
-
+      
       //------------------------------------------------------------
       // HACK for negative value stacking
       if (stacked)
@@ -101,7 +118,7 @@ nv.models.multiBar = function() {
       var seriesData = (xDomain && yDomain) ? [] : // if we know xDomain and yDomain, no need to calculate
             data.map(function(d) {
               return d.values.map(function(d,i) {
-                return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1 }
+                return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1}
               })
             });
 
@@ -109,7 +126,10 @@ nv.models.multiBar = function() {
           .rangeBands(xRange || [0, availableWidth], groupSpacing);
 
       //y   .domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { return d.y + (stacked ? d.y1 : 0) }).concat(forceY)))
-      y   .domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { return stacked ? (d.y > 0 ? d.y1 : d.y1 + d.y ) : d.y }).concat(forceY)))
+      y   .domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { 
+            return stacked ? (getY(d) > 0 ? d.y1 : d.y1 + getY(d) ) : getY(d) 
+            })
+          .concat(forceY)))
           .range(yRange || [availableHeight, 0]);
 
       // If scale's domain don't have a range, slightly adjust to make one... so a chart can show a single data point
@@ -454,6 +474,12 @@ nv.models.multiBar = function() {
     return chart;
   };
 
+
+chart.normalized = function(_) {
+    if (!arguments.length) return normalized;
+    normalized = _;
+    return chart;
+  };
   //============================================================
 
 

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -49,7 +49,7 @@ nv.models.multiBar = function() {
       var availableWidth = width - margin.left - margin.right,
           availableHeight = height - margin.top - margin.bottom,
           container = d3.select(this);
-      
+
       if(hideable && data.length) hideable = [{
         values: data[0].values.map(function(d) {
         return {
@@ -91,7 +91,8 @@ nv.models.multiBar = function() {
           point.series = i;
         });
       });
-      
+
+
       //------------------------------------------------------------
       // HACK for negative value stacking
       if (stacked)
@@ -118,7 +119,7 @@ nv.models.multiBar = function() {
       var seriesData = (xDomain && yDomain) ? [] : // if we know xDomain and yDomain, no need to calculate
             data.map(function(d) {
               return d.values.map(function(d,i) {
-                return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1}
+                return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1 }
               })
             });
 
@@ -126,10 +127,7 @@ nv.models.multiBar = function() {
           .rangeBands(xRange || [0, availableWidth], groupSpacing);
 
       //y   .domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { return d.y + (stacked ? d.y1 : 0) }).concat(forceY)))
-      y   .domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { 
-            return stacked ? (getY(d) > 0 ? d.y1 : d.y1 + getY(d) ) : getY(d) 
-            })
-          .concat(forceY)))
+      y   .domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { return stacked ? (getY(d) > 0 ? d.y1 : d.y1 + getY(d) ) : getY(d) }).concat(forceY)))
           .range(yRange || [availableHeight, 0]);
 
       // If scale's domain don't have a range, slightly adjust to make one... so a chart can show a single data point

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -56,7 +56,7 @@ nv.models.multiBarChart = function() {
     .orient((rightAlignYAxis) ? 'right' : 'left')
     .tickFormat(d3.format(',.1f'))
     ;
-  
+
   controls.updateState(false);
   //============================================================
 
@@ -313,8 +313,7 @@ nv.models.multiBarChart = function() {
 
       legend.dispatch.on('stateChange', function(newState) { 
         state = newState;
-        dispatch.stateChange(state);
-        
+        dispatch.stateChange(state);     
         chart.update();
       });
 
@@ -376,8 +375,7 @@ nv.models.multiBarChart = function() {
           multibar.stacked(e.stacked);
           multibar.normalized(e.normalized);
           state.stacked = e.stacked;
-          state.normalized = e.normalized;
-          
+          state.normalized = e.normalized;    
         }
 
         chart.update();

--- a/test/multiBarChartTest.html
+++ b/test/multiBarChartTest.html
@@ -36,7 +36,10 @@
     Chart with 0 data points
     <svg></svg>
   </div>
-
+ <div class='chart half' id="chart8">
+    Chart with normalized stack enabled, 18 series, 7 data points per series.
+    <svg></svg>
+  </div>
 <script src="../lib/d3.v3.js"></script>
 <script src="../nv.d3.js"></script>
 <script src="../src/tooltip.js"></script>
@@ -108,6 +111,11 @@ defaultChartConfig("chart6",dataFactory(1,2),{
 
 defaultChartConfig("chart7",dataFactory(0,0),{
   delay:0
+});
+
+defaultChartConfig("chart8",dataFactory(18,7),{
+  delay:800,
+  allowNormalized: true
 });
 
 function defaultChartConfig(containerId, data, chartOptions) {


### PR DESCRIPTION
This pull request mplements a new mode for multiBarChart called "stacked normalized". It displays bars in stacked format but normalized values from 0-100%.

## Modified files:
* models/multiBarChart.js
* models/multiBar.js
* test/multiBarChartTest.html (added new chart 8)

## Examples:
* examples/multiBarChartNorm.html

## Notes/Limitations:
For backward compatibility reasons to old multiCharts the new feature is only enabled if "allowNormalized" is passed to the chart during construction.
The current version technically works (meaning it does not crash) with negative values but the output is mainly crap. In order to keep modifications as small as possible the chart function in multiBar.js now internally works on a deep copy of the original data. Normalization will then modify the actual values of that copied data to to 0.0-1.0 domain. All other logic and access to variables did not need modification.
The chart.state() function in multiBarChart.js will now always dispatch a changeState event if a new state is passed in.