### PR TITLE
fix axisLabel failing when scale.range returns an array of one

### DIFF
--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -80,7 +80,8 @@ nv.models.axis = function() {
       switch (axis.orient()) {
         case 'top':
           axisLabel.enter().append('text').attr('class', 'nv-axislabel');
-          var w = (scale.range().length==2) ? scale.range()[1] : (scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]));
+          var rng = scale.range();
+          var w = (rng.length<=2) ? rng[rng.length-1] : (rng[rng.length-1]+(rng[1]-rng[0]));
           axisLabel
               .attr('text-anchor', 'middle')
               .attr('y', 0)
@@ -127,7 +128,8 @@ nv.models.axis = function() {
               .style('text-anchor', rotateLabels%360 > 0 ? 'start' : 'end');
           }
           axisLabel.enter().append('text').attr('class', 'nv-axislabel');
-          var w = (scale.range().length==2) ? scale.range()[1] : (scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]));
+          var rng = scale.range();
+          var w = (rng.length<=2) ? rng[rng.length-1] : (rng[rng.length-1]+(rng[1]-rng[0]));
           axisLabel
               .attr('text-anchor', 'middle')
               .attr('y', xLabelMargin)


### PR DESCRIPTION
We ran into an issue where in a discrete bar chart `scale.range()` would return an array with only one element. In that case `(scale.range()[scale.range().length-1]+(scale.range()[1]-scale.range()[0]))` returns `NaN`. 

This PR allows the calculation to work with 1-element-arrays by returning that one element. The rest remains the same. 