### PR TITLE
Fix for number of ticks bigger than number of values

### DIFF
--- a/nv.d3.js
+++ b/nv.d3.js
@@ -13771,6 +13771,7 @@ nv.models.stackedAreaChart = function() {
     , cData = ['Stacked','Stream','Expanded']
     , controlLabels = {}
     , transitionDuration = 250
+    , nvalues = 0
     ;
 
   xAxis
@@ -14001,9 +14002,17 @@ nv.models.stackedAreaChart = function() {
       // Setup Axes
 
       if (showXAxis) {
+        var numberTicks;
+        if (nvalues <= 2) {
+          numberTicks = 0;
+        } else if (availableWidth / 100 > nvalues) {
+          numberTicks =  nvalues - 1;
+        } else {
+          numberTicks = availableWidth / 100;
+        }
         xAxis
           .scale(x)
-          .ticks( availableWidth / 100 )
+          .ticks(numberTicks)
           .tickSize( -availableHeight, 0);
 
         g.select('.nv-x.nv-axis')

--- a/nv.d3.js
+++ b/nv.d3.js
@@ -13805,6 +13805,7 @@ nv.models.stackedAreaChart = function() {
 
   function chart(selection) {
     selection.each(function(data) {
+      nvalues = data[0].values.length;	
       var container = d3.select(this),
           that = this;
 

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -39,6 +39,7 @@ nv.models.stackedAreaChart = function() {
     , cData = ['Stacked','Stream','Expanded']
     , controlLabels = {}
     , transitionDuration = 250
+    , nvalues = 0
     ;
 
   xAxis
@@ -269,9 +270,17 @@ nv.models.stackedAreaChart = function() {
       // Setup Axes
 
       if (showXAxis) {
+        var numberTicks;
+        if (nvalues <= 2) {
+          numberTicks = 0;
+        } else if (availableWidth / 100 > nvalues) {
+          numberTicks =  nvalues - 1;
+        } else {
+          numberTicks = availableWidth / 100;
+        }
         xAxis
           .scale(x)
-          .ticks( availableWidth / 100 )
+          .ticks(numberTicks)
           .tickSize( -availableHeight, 0);
 
         g.select('.nv-x.nv-axis')

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -73,6 +73,7 @@ nv.models.stackedAreaChart = function() {
 
   function chart(selection) {
     selection.each(function(data) {
+      nvalues = data[0].values.length;
       var container = d3.select(this),
           that = this;
 


### PR DESCRIPTION
This is a fix for x axis repeating values when the available width for the stackedAreaChart is bigger than the number of values in the data array
![screen shot 2014-08-19 at 12 12 28](https://cloud.githubusercontent.com/assets/559229/3964471/ba2da39c-2789-11e4-9e33-8d428ad4677b.png)