### PR TITLE
Use nvd3-specific CSS rules

### DIFF
--- a/nv.d3.css
+++ b/nv.d3.css
@@ -143,7 +143,7 @@
  */
 
 
-svg {
+.nvd3svg {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -khtml-user-select: none;
@@ -157,11 +157,11 @@ svg {
 }
 
 
-svg text {
+.nvd3svg text {
   font: normal 12px Arial;
 }
 
-svg .title {
+.nvd3svg .title {
  font: bold 14px Arial;
 }
 


### PR DESCRIPTION
Simply using `svg` is not a good idea as it can interfere with other `svg` elements that do not use `nvd3` but just pure `d3`. Changing `svg` to `.nvd3svg` means that every `svg` element that will be used by `nvd3` should be given an `nvd3svg` class for these CSS rules to take effect.

I'm not sure if this fits in with this library's philosophy, but we intend to use it this way internally to avoid CSS rule clashes. Feel free to close this pull request if it's not in line with what you are moving towards.
