### PR TITLE
Control legend items spacing a bit better

### DIFF
--- a/examples/legend.html
+++ b/examples/legend.html
@@ -23,7 +23,8 @@ nv.addGraph({
 
     var chart = nv.models.legend()
                 .width(width)
-                .height(height);
+                .height(height)
+                .legendExtraDistance(40);
 
     chart.dispatch.on('legendClick', function(d,i) { console.log(d,i) });
 

--- a/src/models/legend.js
+++ b/src/models/legend.js
@@ -7,6 +7,7 @@ nv.models.legend = function() {
   var margin = {top: 5, right: 0, bottom: 5, left: 0}
     , width = 400
     , height = 20
+    , legendExtraDistance = 0
     , getKey = function(d) { return d.key }
     , color = nv.utils.defaultColor()
     , align = true
@@ -117,7 +118,7 @@ nv.models.legend = function() {
                 nodeTextLength = nv.utils.calcApproxTextWidth(legendText);
               }
 
-              seriesWidths.push(nodeTextLength + 28); // 28 is ~ the width of the circle plus some padding
+              seriesWidths.push(nodeTextLength + 28 + legendExtraDistance); // 28 is ~ the width of the circle plus some padding
             });
 
         var seriesPerRow = 0;
@@ -174,7 +175,7 @@ nv.models.legend = function() {
             xpos;
         series
             .attr('transform', function(d, i) {
-              var length = d3.select(this).select('text').node().getComputedTextLength() + 28;
+              var length = d3.select(this).select('text').node().getComputedTextLength() + 28 + legendExtraDistance;
               xpos = newxpos;
 
               if (width < margin.left + margin.right + xpos + length) {
@@ -262,6 +263,13 @@ nv.models.legend = function() {
   chart.radioButtonMode = function(_) {
     if (!arguments.length) return radioButtonMode;
     radioButtonMode = _;
+    return chart;
+  };
+
+
+  chart.legendExtraDistance = function(_) {
+    if (!arguments.length) return legendExtraDistance;
+    legendExtraDistance = _;
     return chart;
   };
 


### PR DESCRIPTION
The way this currently works is that legend items have a fixed space between one another, however in some cases it might be necessary to customise that space. `legendExtraDistance` will do just that; it's `0` by default and can be set to any value that you want to extend the distance between legend items by.

You can see it in action in the `legend.html` example which I've also updated.