### PR TITLE
Fix broken legend when data is changed

### DIFF
--- a/src/models/legend.js
+++ b/src/models/legend.js
@@ -47,6 +47,10 @@ nv.models.legend = function() {
             dispatch.legendMouseout(d,i);
           })
           .on('click', function(d,i) {
+            
+            // Re-associate this node to the current data in case it changed.
+            data[i] = d;
+            
             dispatch.legendClick(d,i);
             if (updateState) {
                if (radioButtonMode) {
@@ -69,6 +73,10 @@ nv.models.legend = function() {
             }
           })
           .on('dblclick', function(d,i) {
+            
+            // Re-associate this node to the current data in case it changed.
+            data[i] = d;
+            
             dispatch.legendDblclick(d,i);
             if (updateState) {
                 //the default behavior of NVD3 legends, when double clicking one,


### PR DESCRIPTION
Not a d3/nvd3 expert, but this is needed to make my custom legend behave (it uses dynamically-generated legend data, not directly the main graph's data).

This should (admittedly not the ideal way) fix errors some other users have also been getting:
http://stackoverflow.com/questions/23015095/nvd3-passing-wrong-event-on-statechange-when-clicking-legend-after-chart-is-re
("data always points to the initial data array").