### PR TITLE
Fix broken links in indentedtree.html

### DIFF
--- a/examples/indentedtree.html
+++ b/examples/indentedtree.html
@@ -23,7 +23,7 @@ body {
 
 var testTree = [{
   key: 'NVD3',
-  url: 'http://novus.github.com/nvd3',
+  url: 'http://nvd3.org/',
   values: [
     {
       key: "Charts",
@@ -31,22 +31,22 @@ var testTree = [{
         {
           key: "Simple Line",
           type: "Historical",
-          url: "http://novus.github.com/nvd3/ghpages/line.html"
+          url: "line.html"
         },
         {
           key: "Scatter / Bubble",
           type: "Snapshot",
-          url: "http://novus.github.com/nvd3/ghpages/scatter.html"
+          url: "scatter.html"
         },
         {
           key: "Stacked / Stream / Expanded Area",
           type: "Historical",
-          url: "http://novus.github.com/nvd3/ghpages/stackedArea.html"
+          url: "stackedArea.html"
         },
         {
           key: "Discrete Bar",
           type: "Snapshot",
-          url: "http://novus.github.com/nvd3/ghpages/discreteBar.html"
+          url: "discreteBar.html"
         },
         {
           key: "Grouped / Stacked Multi-Bar",
@@ -56,22 +56,22 @@ var testTree = [{
         {
           key: "Horizontal Grouped Bar",
           type: "Snapshot",
-          url: "http://novus.github.com/nvd3/ghpages/multiBarHorizontal.html"
+          url: "multiBarHorizontal.html"
         },
         {
           key: "Line and Bar Combo",
           type: "Historical",
-          url: "http://novus.github.com/nvd3/ghpages/linePlusBar.html"
+          url: "linePlusBar.html"
         },
         {
           key: "Cumulative Line",
           type: "Historical",
-          url: "http://novus.github.com/nvd3/ghpages/cumulativeLine.html"
+          url: "cumulativeLine.html"
         },
         {
           key: "Line with View Finder",
           type: "Historical",
-          url: "http://novus.github.com/nvd3/ghpages/lineWithFocus.html"
+          url: "lineWithFocus.html"
         }
       ]
     },
@@ -81,7 +81,7 @@ var testTree = [{
         {
           key: "Legend",
           type: "Universal",
-          url: "http://novus.github.com/nvd3/examples/legend.html"
+          url: "legend.html"
         }
       ]
     }


### PR DESCRIPTION
Great work on nvd3. I'm using it at a green-tech start-up to chart electricity consumption...

1. Update link to nvd3,org home page.
2. Make all links to other examples relative, so they won't break so easily.