### PR TITLE
Prefixed svg element in css to avoid affecting other svg elements from other libraries.

### DIFF
--- a/src/nv.d3.css
+++ b/src/nv.d3.css
@@ -143,7 +143,7 @@
  */
 
 
-svg {
+.nvd3 svg {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -khtml-user-select: none;
@@ -157,11 +157,11 @@ svg {
 }
 
 
-svg text {
+.nvd3 svg text {
   font: normal 12px Arial;
 }
 
-svg .title {
+.nvd3 svg .title {
  font: bold 14px Arial;
 }
 


### PR DESCRIPTION
The svg classes on the css are not prefixed by nvd3 what causes other svgs not generated with nvd3 to be affected.