### PR TITLE
Firefox fails to redraw charts

### DIFF
--- a/nv.d3.js
+++ b/nv.d3.js
@@ -1133,7 +1133,7 @@ nv.utils.optionsFunc = function(args) {
           if (rotateLabels%360) {
             //Calculate the longest xTick width
             xTicks.each(function(d,i){
-              var width = this.getBBox().width;
+              var width = this.getBoundingClientRect().width;
               if(width > maxTextWidth) maxTextWidth = width;
             });
             //Convert to radians before calculating sin. Add 30 to margin for healthy padding.


### PR DESCRIPTION
Hello! I found one issue related with this bug https://bugzilla.mozilla.org/show_bug.cgi?id=612118. But this issue specific for SVG elements. 
When I try to redraw charts, Firefox fails with NS_ERROR_FAILURE. 
I replaced getBBox() to getBoundingClientRect(). It works in IE, Chrome, FF. getBoundingClientRect() works pretty well with svg elements in all browsers and in more faster http://jsperf.com/getboundingclientrect-vs-offsetwidth/8. 