### PR TITLE
Move minimum D3 version to 3.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Novus has decided to keep the library in sync with what is in nvd3-community mas
 
 **D3 Versioning Note**
 
-NVD3 should work with the latest d3.js (version 3.5), but I did notice that the interactive guideline tooltip was broken for d3.js 3.5.  Changing it to d3.js 3.3.13 fixes it. This will need to be investigated.
+NVD3 should work with the latest d3.js version 3.5.3 and later.  Along with `pieChart` options `padAngle` and `cornerRadius`, the interactive guideline tooltip now requires these later versions of D3 (3.4.4+, specifically, to get interactive tooltips). The interactive guide lines rely on the more recent `d3.bisector()` method which treats accessors taking two parameters (the second being the element index) as comparators (see [d3.bisector()](https://github.com/mbostock/d3/wiki/Arrays#d3_bisector)).
 
 **1.7.1** Changes:
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "nvd3",
-  "version": "1.7.1",
   "homepage": "http://www.nvd3.org",
   "authors": [
     "Bob Monteverde",
@@ -22,7 +21,7 @@
   ],
   "license": "Apache License, v2.0",
   "dependencies": {
-    "d3": "^3.3.13"
+    "d3": "^3.4.4"
   },
   "ignore": [
     "**/.*",
@@ -37,11 +36,5 @@
     "*.xml",
     "*.json",
     "*.md"
-  ],
-  "resolutions": {
-    "d3": "^3.3.13"
-  },
-  "devDependencies": {
-    "d3": "^3.3.13"
-  }
+  ]
 }

--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -227,15 +227,21 @@ nv.interactiveBisect = function (values, searchVal, xAccessor) {
     if (! (values instanceof Array)) {
         return null;
     }
+    var _xAccessor;
     if (typeof xAccessor !== 'function') {
-        xAccessor = function(d,i) {
+        _xAccessor = function(d) {
             return d.x;
         }
+    } else {
+        _xAccessor = xAccessor;
+    }
+    var _cmp = function(d, v) {
+        return _xAccessor(d) - v;
     }
 
-    var bisect = d3.bisector(xAccessor).left;
+    var bisect = d3.bisector(_cmp).left;
     var index = d3.max([0, bisect(values,searchVal) - 1]);
-    var currentValue = xAccessor(values[index], index);
+    var currentValue = _xAccessor(values[index]);
 
     if (typeof currentValue === 'undefined') {
         currentValue = index;
@@ -246,7 +252,7 @@ nv.interactiveBisect = function (values, searchVal, xAccessor) {
     }
 
     var nextIndex = d3.min([index+1, values.length - 1]);
-    var nextValue = xAccessor(values[nextIndex], nextIndex);
+    var nextValue = _xAccessor(values[nextIndex]);
 
     if (typeof nextValue === 'undefined') {
         nextValue = nextIndex;

--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -236,6 +236,15 @@ nv.interactiveBisect = function (values, searchVal, xAccessor) {
         _xAccessor = xAccessor;
     }
     var _cmp = function(d, v) {
+        // Accessors are no longer passed the index of the element along with
+        // the element itself when invoked by d3.bisector.
+        //
+        // Starting at D3 v3.4.4, d3.bisector() started inspecting the
+        // function passed to determine if it should consider it an accessor
+        // or a comparator. This meant that accessors that take two arguments
+        // (expecting an index as the second parameter) are treated as
+        // comparators where the second argument is the search value against
+        // which the first argument is compared.
         return _xAccessor(d) - v;
     }
 

--- a/test/mocha/utils.coffee
+++ b/test/mocha/utils.coffee
@@ -45,6 +45,10 @@ describe 'NVD3', ->
       returnedFunction({},3).should.be.equal '#000'
 
   describe 'Interactive Bisect', ->
+    it 'no accessor', ->
+      list = [{ x:0 },{ x:1 },{ x:1 },{ x:2 },{ x:3 },{ x:5 },{ x:8 },{ x:13 },{ x:21 },{ x:34 }]
+      expect(nv.interactiveBisect(list,7)).to.equal 6
+
     runTest = (list, searchVal, accessor = null)->
       xAcc = unless accessor?
         (d)-> d
@@ -55,6 +59,9 @@ describe 'NVD3', ->
 
     it 'exists', ->
       expect(nv.interactiveBisect).to.exist
+
+    it 'returns null when no array', ->
+      expect(nv.interactiveBisect('bad', 'a')).to.equal null
 
     it 'basic test', ->
       expect(runTest([0,1,2,3,4,5], 3)).to.equal 3
@@ -88,21 +95,6 @@ describe 'NVD3', ->
     it 'fibonacci - inbetween item (right)', ->
       list = [0,1,1,2,3,5,8,13,21,34]
       expect(runTest(list,20)).to.equal 8
-
-    it 'accessor in index mode - existing item', ->
-      x = (d,i)-> i
-      list = [0,1,1,2,3,5,8,13,21,34]
-      expect(runTest(list,7,x)).to.equal 7
-
-    it 'accessor in index mode - inbetween item 1', ->
-      x = (d,i)-> i
-      list = [0,1,1,2,3,5,8,13,21,34]
-      expect(runTest(list,7.3,x)).to.equal 7
-
-    it 'accessor in index mode - inbetween item 2', ->
-      x = (d,i)-> i
-      list = [0,1,1,2,3,5,8,13,21,34]
-      expect(runTest(list,7.50001,x)).to.equal 8
 
     it 'empty array', ->
       expect(runTest([],4)).to.equal 0


### PR DESCRIPTION
As of D3 commit:

https://github.com/mbostock/d3/commit/3c7cc81b6233289263525b581d635ad9f8d9dd37

We are no longer able to use an array accessor that accepts two
parameters (the second being the index of the first parameter in the
given array), since d3.bisector() will consider it a comparison
function instead of an accessor.

There does not appear to be a way to get the index value of the element
being considered in the context of the accessor.

As a result, this commit proposes we drop the interactiveBisect()
support for accessors accepting a second parameter being the index of
the first in a given array.

We now wrap all x-accessors passed to interactiveBisect() hiding the
second parameter, using an internal comparator instead.

This commit also attempts to get the coverage to 100% for
interactiveBisect().

See issue #754 as well.