### PR TITLE
Expose utils methods of container sizing and available dimensions

### DIFF
--- a/src/models/bulletChart.js
+++ b/src/models/bulletChart.js
@@ -47,8 +47,7 @@ nv.models.bulletChart = function() {
             var container = d3.select(this);
             nv.utils.initSVG(container);
 
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
                 availableHeight = height - margin.top - margin.bottom,
                 that = this;
 

--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -109,10 +109,8 @@ nv.models.cumulativeLineChart = function() {
             container.classed('nv-chart-' + id, true);
             var that = this;
 
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() {
                 if (duration === 0)
@@ -246,8 +244,7 @@ nv.models.cumulativeLineChart = function() {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom;
+                    availableHeight = nv.utils.availableHeight(height, container, margin);
                 }
 
                 g.select('.nv-legendWrap')

--- a/src/models/discreteBarChart.js
+++ b/src/models/discreteBarChart.js
@@ -68,10 +68,8 @@ nv.models.discreteBarChart = function() {
             var container = d3.select(this),
                 that = this;
             nv.utils.initSVG(container);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() {
                 dispatch.beforeUpdate();

--- a/src/models/historicalBar.js
+++ b/src/models/historicalBar.js
@@ -34,10 +34,8 @@ nv.models.historicalBar = function() {
             renderWatch.reset();
 
             var container = d3.select(this);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                - margin.left - margin.right;
-            var availableHeight = (height || parseInt(container.style('height')) || 400)
-                - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             nv.utils.initSVG(container);
 

--- a/src/models/historicalBarChart.js
+++ b/src/models/historicalBarChart.js
@@ -83,11 +83,8 @@ nv.models.historicalBarChart = function(bar_model) {
             var container = d3.select(this),
                 that = this;
             nv.utils.initSVG(container);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
-
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() { container.transition().duration(transitionDuration).call(chart) };
             chart.container = this;
@@ -150,8 +147,7 @@ nv.models.historicalBarChart = function(bar_model) {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom;
+                    availableHeight = nv.utils.availableHeight(height, container, margin);
                 }
 
                 wrap.select('.nv-legendWrap')

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -86,11 +86,8 @@ nv.models.lineChart = function() {
             var container = d3.select(this),
                 that = this;
             nv.utils.initSVG(container);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
-
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() {
                 if (duration === 0)
@@ -169,8 +166,7 @@ nv.models.lineChart = function() {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom;
+                    availableHeight = nv.utils.availableHeight(height, container, margin);
                 }
 
                 wrap.select('.nv-legendWrap')

--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -119,10 +119,9 @@ nv.models.linePlusBarChart = function() {
             var container = d3.select(this),
                 that = this;
             nv.utils.initSVG(container);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight1 = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom - (focusEnable ? focusHeight : 0) ,
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight1 = nv.utils.availableHeight(height, container, margin)
+                    - (focusEnable ? focusHeight : 0),
                 availableHeight2 = focusHeight - margin2.top - margin2.bottom;
 
             chart.update = function() { container.transition().duration(transitionDuration).call(chart); };
@@ -243,8 +242,8 @@ nv.models.linePlusBarChart = function() {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight1 = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom - focusHeight;
+                    // FIXME: shouldn't this be "- (focusEnabled ? focusHeight : 0)"?
+                    availableHeight1 = nv.utils.availableHeight(height, container, margin) - focusHeight;
                 }
 
                 g.select('.nv-legendWrap')

--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -96,10 +96,8 @@ nv.models.lineWithFocusChart = function() {
             var container = d3.select(this),
                 that = this;
             nv.utils.initSVG(container);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight1 = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom - height2,
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight1 = nv.utils.availableHeight(height, container, margin) - height2,
                 availableHeight2 = height2 - margin2.top - margin2.bottom;
 
             chart.update = function() { container.transition().duration(transitionDuration).call(chart) };
@@ -178,8 +176,7 @@ nv.models.lineWithFocusChart = function() {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight1 = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom - height2;
+                    availableHeight1 = nv.utils.availableHeight(height, container, margin) - height2;
                 }
 
                 g.select('.nv-legendWrap')

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -107,10 +107,8 @@ nv.models.multiBarChart = function() {
             var container = d3.select(this),
                 that = this;
             nv.utils.initSVG(container);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() {
                 if (duration === 0)
@@ -185,8 +183,7 @@ nv.models.multiBarChart = function() {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom;
+                    availableHeight = nv.utils.availableHeight(height, container, margin);
                 }
 
                 g.select('.nv-legendWrap')

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -103,10 +103,8 @@ nv.models.multiBarHorizontalChart = function() {
             var container = d3.select(this),
                 that = this;
             nv.utils.initSVG(container);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() { container.transition().duration(duration).call(chart) };
             chart.container = this;
@@ -178,8 +176,7 @@ nv.models.multiBarHorizontalChart = function() {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom;
+                    availableHeight = nv.utils.availableHeight(height, container, margin);
                 }
 
                 g.select('.nv-legendWrap')

--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -69,10 +69,8 @@ nv.models.multiChart = function() {
             chart.update = function() { container.transition().call(chart); };
             chart.container = this;
 
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             var dataLines1 = data.filter(function(d) {return d.type == 'line' && d.yAxis == 1});
             var dataLines2 = data.filter(function(d) {return d.type == 'line' && d.yAxis == 2});
@@ -154,8 +152,7 @@ nv.models.multiChart = function() {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom;
+                    availableHeight = nv.utils.availableHeight(height, container, margin);
                 }
 
                 g.select('.legendWrap')

--- a/src/models/ohlcBar.js
+++ b/src/models/ohlcBar.js
@@ -38,10 +38,8 @@ nv.models.ohlcBar = function() {
     function chart(selection) {
         selection.each(function(data) {
             var container = d3.select(this);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                - margin.left - margin.right;
-            var availableHeight = (height || parseInt(container.style('height')) || 400)
-                - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             nv.utils.initSVG(container);
 

--- a/src/models/parallelCoordinates.js
+++ b/src/models/parallelCoordinates.js
@@ -28,10 +28,8 @@ nv.models.parallelCoordinates = function() {
     function chart(selection) {
         selection.each(function(data) {
             var container = d3.select(this);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                - margin.left - margin.right;
-            var availableHeight = (height || parseInt(container.style('height')) || 400)
-                - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             nv.utils.initSVG(container);
 

--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -74,11 +74,8 @@ nv.models.pieChart = function() {
             nv.utils.initSVG(container);
 
             var that = this;
-            var canvasWidth = (width || parseInt(container.style('width'), 10) || 960),
-                canvasHeight = (height || parseInt(container.style('height'), 10) || 400),
-                availableWidth = canvasWidth - margin.left - margin.right,
-                availableHeight = canvasHeight - margin.top - margin.bottom
-                ;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() { container.transition().call(chart); };
             chart.container = this;
@@ -139,8 +136,7 @@ nv.models.pieChart = function() {
 
                     if ( margin.top != legend.height()) {
                         margin.top = legend.height();
-                        availableHeight = (height || parseInt(container.style('height')) || 400)
-                            - margin.top - margin.bottom;
+                        availableHeight = nv.utils.availableHeight(height, container, margin);
                     }
 
                     wrap.select('.nv-legendWrap')
@@ -154,8 +150,8 @@ nv.models.pieChart = function() {
 
                     if ( margin.right != legend.width()) {
                         margin.right = legend.width();
-                        availableWidth = (width || parseInt(container.style('width')) || 600)
-                            - margin.right - margin.left;
+                        // FIXME: Do we need the default of 600 different from 960?
+                        availableWidth = nv.utils.availableWidth(width, container, margin);
                     }
 
                     wrap.select('.nv-legendWrap')

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -56,10 +56,8 @@ nv.models.scatter = function() {
         renderWatch.reset();
         selection.each(function(data) {
             var container = d3.select(this);
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                - margin.left - margin.right;
-            var availableHeight = (height || parseInt(container.style('height')) || 400)
-                - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             nv.utils.initSVG(container);
 

--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -113,10 +113,8 @@ nv.models.scatterChart = function() {
                 that = this;
             nv.utils.initSVG(container);
 
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() {
                 if (duration === 0)
@@ -206,8 +204,7 @@ nv.models.scatterChart = function() {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom;
+                    availableHeight = nv.utils.availableHeight(height, container, margin);
                 }
 
                 wrap.select('.nv-legendWrap')

--- a/src/models/sparklinePlus.js
+++ b/src/models/sparklinePlus.js
@@ -28,10 +28,8 @@ nv.models.sparklinePlus = function() {
             var container = d3.select(this);
             nv.utils.initSVG(container);
 
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() { chart(selection) };
             chart.container = this;

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -96,10 +96,8 @@ nv.models.stackedAreaChart = function() {
                 that = this;
             nv.utils.initSVG(container);
 
-            var availableWidth = (width  || parseInt(container.style('width')) || 960)
-                    - margin.left - margin.right,
-                availableHeight = (height || parseInt(container.style('height')) || 400)
-                    - margin.top - margin.bottom;
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
             chart.update = function() { container.transition().duration(duration).call(chart); };
             chart.container = this;
@@ -170,8 +168,7 @@ nv.models.stackedAreaChart = function() {
 
                 if ( margin.top != legend.height()) {
                     margin.top = legend.height();
-                    availableHeight = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom;
+                    availableHeight = nv.utils.availableHeight(height, container, margin);
                 }
 
                 g.select('.nv-legendWrap')
@@ -222,8 +219,7 @@ nv.models.stackedAreaChart = function() {
 
                 if ( margin.top != Math.max(controls.height(), legend.height()) ) {
                     margin.top = Math.max(controls.height(), legend.height());
-                    availableHeight = (height || parseInt(container.style('height')) || 400)
-                        - margin.top - margin.bottom;
+                    availableHeight = nv.utils.availableHeight(height, container, margin);
                 }
 
                 g.select('.nv-controlsWrap')

--- a/src/utils.js
+++ b/src/utils.js
@@ -561,3 +561,34 @@ Runs common initialize code on the svg before the chart builds
 nv.utils.initSVG = function(svg) {
     svg.classed({'nvd3-svg':true});
 };
+
+
+/*
+Sanitize and provide default for the container height.
+*/
+nv.utils.sanitizeHeight = function(height, container) {
+    return (height || parseInt(container.style('height')) || 400);
+}
+
+
+/*
+Sanitize and provide default for the container width.
+*/
+nv.utils.sanitizeWidth = function(width, container) {
+    return (width || parseInt(container.style('width')) || 960);
+}
+
+
+/*
+Calculate the available height for a chart.
+*/
+nv.utils.availableHeight = function(height, container, margin) {
+    return nv.utils.sanitizeHeight(height, container) - margin.top - margin.bottom;
+}
+
+/*
+Calculate the available width for a chart.
+*/
+nv.utils.availableWidth = function(width, container, margin) {
+    return nv.utils.sanitizeWidth(width, container) - margin.left - margin.right;
+}

--- a/test/mocha/utils.coffee
+++ b/test/mocha/utils.coffee
@@ -13,6 +13,10 @@ describe 'NVD3', ->
       'nv.utils.deepExtend'
       'nv.utils.state'
       'nv.utils.optionsFunc'
+      'nv.utils.sanitizeHeight'
+      'nv.utils.sanitizeWidth'
+      'nv.utils.availableHeight'
+      'nv.utils.availableWidth'
     ]
 
     describe 'has ', ->
@@ -44,8 +48,52 @@ describe 'NVD3', ->
       returnedFunction({},2).should.be.equal '#aaa'
       returnedFunction({},3).should.be.equal '#000'
 
+  describe 'Sanitize Height and Width for a Container', ->
+    it 'provides default height', ->
+      h = (arg) -> return null
+      cont = { style: h }
+      expect(nv.utils.sanitizeHeight(null, cont)).to.equal 400
+      expect(nv.utils.sanitizeHeight(undefined, cont)).to.equal 400
+      expect(nv.utils.sanitizeHeight(0, cont)).to.equal 400
+    it 'provides default width', ->
+      w = (arg) -> return null
+      cont = { style: w }
+      expect(nv.utils.sanitizeWidth(null, cont)).to.equal 960
+      expect(nv.utils.sanitizeWidth(undefined, cont)).to.equal 960
+      expect(nv.utils.sanitizeWidth(0, cont)).to.equal 960
+    it 'uses container height', ->
+      h = (arg) -> return 404
+      cont = { style: h }
+      expect(nv.utils.sanitizeHeight(null, cont)).to.equal 404
+    it 'uses container width', ->
+      w = (arg) -> return 964
+      cont = { style: w }
+      expect(nv.utils.sanitizeWidth(null, cont)).to.equal 964
+    it 'uses given height', ->
+      h = (arg) -> return 404
+      cont = { style: h }
+      expect(nv.utils.sanitizeHeight(408, cont)).to.equal 408
+    it 'uses given width', ->
+      w = (arg) -> return 964
+      cont = { style: w }
+      expect(nv.utils.sanitizeWidth(968, cont)).to.equal 968
+
+  describe 'Available Container Height and Width', ->
+    it 'calculates height properly', ->
+      m = { left: 5, right: 6, top: 7, bottom: 8 }
+      h = (arg) -> return 404
+      cont = { style: h }
+      expect(nv.utils.availableHeight(300, cont, m)).to.equal 285
+      expect(nv.utils.availableHeight(0, cont, m)).to.equal 389
+    it 'calculates width properly', ->
+      m = { left: 5, right: 6, top: 7, bottom: 8 }
+      w = (arg) -> return 964
+      cont = { style: w }
+      expect(nv.utils.availableWidth(300, cont, m)).to.equal 289
+      expect(nv.utils.availableWidth(0, cont, m)).to.equal 953
+
   describe 'Interactive Bisect', ->
-    it 'no accessor', ->
+    it 'works with no accessor', ->
       list = [{ x:0 },{ x:1 },{ x:1 },{ x:2 },{ x:3 },{ x:5 },{ x:8 },{ x:13 },{ x:21 },{ x:34 }]
       expect(nv.interactiveBisect(list,7)).to.equal 6
 


### PR DESCRIPTION
This is an attempt to make it easier for callers to figure out chart sizing, while reducing duplicate code of such calculations.

The angularjs-nvd3-directives project issues https://github.com/angularjs-nvd3-directives/angularjs-nvd3-directives/issues/56, and https://github.com/angularjs-nvd3-directives/angularjs-nvd3-directives/issues/11, show that initial need.