### PR TITLE
Add packaging for Meteor.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,0 +1,14 @@
+Package.describe({
+    "name": 'novus:nvd3',
+    summary: 'Nvd3.org charts.',
+    version: "1.7.1",
+    git: "https://github.com/novus/nvd3"
+});
+
+Package.on_use(function (api) {
+    api.versionsFrom("METEOR@1.0");
+    api.use('d3js:d3', 'client');
+
+    api.add_files('build/nv.d3.js', 'client');
+    api.add_files('build/nv.d3.css', 'client');
+});


### PR DESCRIPTION
Please add official meteor packaging for nvd3. Currently there are 6  nvd3  packages floating on atmosphere https://atmospherejs.com/?q=nvd3 in different state of disrepair. Having official package will greatly help community to keep up with the latest update of the beautiful  nvd3 charting library.
The steps required are 
1 Install meteor https://www.meteor.com/installdeveloper 
2  Go to https://atmospherejs.com/  => sign in => create  meteor developer  account for novus
3 Add the package.js file
4 Publish the package https://atmospherejs.com/i/publishing

Currently the package.js uses d3js:d3 which is official d3 package for package.
See discussion https://github.com/mbostock/d3/pull/2130 

