### PR TITLE
Add options function binding to scatterChart

### DIFF
--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -404,6 +404,7 @@ nv.models.scatterChart = function() {
     chart.distX = distX;
     chart.distY = distY;
 
+    chart.options = nv.utils.optionsFunc.bind(chart);
     chart._options = Object.create({}, {
         // simple options, just get/set the necessary values
         width:      {get: function(){return width;}, set: function(_){width=_;}},

--- a/test/mocha/bullet.coffee
+++ b/test/mocha/bullet.coffee
@@ -47,8 +47,9 @@ describe 'NVD3', ->
             builder1.teardown()
 
         it 'api check', ->
-            for opt of options
-                should.exist builder1.model[opt](), "#{opt} can be called"
+          should.exist builder1.model.options, 'options exposed'
+          for opt of options
+              should.exist builder1.model[opt](), "#{opt} can be called"
 
         it 'renders', ->
             wrap = builder1.$ 'g.nvd3.nv-bulletChart'

--- a/test/mocha/cumulative-line.coffee
+++ b/test/mocha/cumulative-line.coffee
@@ -67,8 +67,9 @@ describe 'NVD3', ->
             builder1.teardown()
 
         it 'api check', ->
-            for opt of options
-                should.exist builder1.model[opt](), "#{opt} can be called"
+          should.exist builder1.model.options, 'options exposed'
+          for opt of options
+              should.exist builder1.model[opt](), "#{opt} can be called"
 
         it 'renders', ->
             wrap = builder1.$ 'g.nvd3.nv-cumulativeLine'

--- a/test/mocha/discretebar.coffee
+++ b/test/mocha/discretebar.coffee
@@ -39,6 +39,7 @@ describe 'NVD3', ->
             builder.teardown()
 
         it 'api check', ->
+            should.exist builder.model.options, 'options exposed'
             for opt of options
                 should.exist builder.model[opt](), "#{opt} can be called"
 

--- a/test/mocha/historical-bar.coffee
+++ b/test/mocha/historical-bar.coffee
@@ -38,6 +38,7 @@ describe 'NVD3', ->
             builder.teardown()
 
         it 'api check', ->
+            should.exist builder.model.options, 'options exposed'
             for opt of options
                 should.exist builder.model[opt](), "#{opt} can be called"
 

--- a/test/mocha/line.coffee
+++ b/test/mocha/line.coffee
@@ -70,6 +70,7 @@ describe 'NVD3', ->
             builder.teardown()
 
         it 'api check', ->
+            should.exist builder.model.options, 'options exposed'
             for opt of options
                 should.exist builder.model[opt](), "#{opt} can be called"
 

--- a/test/mocha/multibar-horizontal.coffee
+++ b/test/mocha/multibar-horizontal.coffee
@@ -56,6 +56,7 @@ describe 'NVD3', ->
             builder.teardown()
 
         it 'api check', ->
+            should.exist builder.model.options, 'options exposed'
             for opt of options
                 should.exist builder.model[opt](), "#{opt} can be called"
 

--- a/test/mocha/multibar.coffee
+++ b/test/mocha/multibar.coffee
@@ -59,6 +59,7 @@ describe 'NVD3', ->
             builder.teardown()
 
         it 'api check', ->
+            should.exist builder.model.options, 'options exposed'
             for opt of options
                 should.exist builder.model[opt](), "#{opt} can be called"
 

--- a/test/mocha/pie.coffee
+++ b/test/mocha/pie.coffee
@@ -46,6 +46,7 @@ describe 'NVD3', ->
             builder.teardown()
 
         it 'api check', ->
+            should.exist builder.model.options, 'options exposed'
             for opt of options
                 should.exist builder.model[opt](), "#{opt} can be called"
 

--- a/test/mocha/scatter.coffee
+++ b/test/mocha/scatter.coffee
@@ -63,6 +63,7 @@ describe 'NVD3', ->
             builder.teardown()
 
         it 'api check', ->
+            should.exist builder.model.options, 'options exposed'
             for opt of options
                 should.exist builder.model[opt], "#{opt} exists"
                 should.exist builder.model[opt](), "#{opt} can be called"

--- a/test/mocha/sparkline.coffee
+++ b/test/mocha/sparkline.coffee
@@ -34,6 +34,7 @@ describe 'NVD3', ->
             builder.teardown()
 
         it 'api check', ->
+            should.exist builder.model.options, 'options exposed'
             for opt of options
                 should.exist builder.model[opt](), "#{opt} can be called"
 

--- a/test/mocha/stacked.coffee
+++ b/test/mocha/stacked.coffee
@@ -61,6 +61,7 @@ describe 'NVD3', ->
             builder.teardown()
 
         it 'api check', ->
+            should.exist builder.model.options, 'options exposed'
             for opt of options
                 should.exist builder.model[opt](), "#{opt} can be called"
 


### PR DESCRIPTION
Refs #785

Every other chart has this. Needed to have chart.options() be the standard way to access a chart's options.