### PR TITLE
Stacked Area: yAxis formatting bug (percentage format sticks)

### DIFF
--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -45,6 +45,7 @@ nv.models.stackedAreaChart = function() {
     xAxis.orient('bottom').tickPadding(7);
     yAxis.orient((rightAlignYAxis) ? 'right' : 'left');
 
+    var oldYTickFormat = null;
     controls.updateState(false);
 
     //============================================================
@@ -258,9 +259,16 @@ nv.models.stackedAreaChart = function() {
             if (showYAxis) {
                 yAxis.scale(y)
                     .ticks(stacked.offset() == 'wiggle' ? 0 : nv.utils.calcTicksY(availableHeight/36, data) )
-                    .tickSize(-availableWidth, 0)
-                    .setTickFormat( (stacked.style() == 'expand' || stacked.style() == 'stack_percent')
-                        ? d3.format('%') : yAxis.tickFormat());
+                    .tickSize(-availableWidth, 0);
+
+                    if (stacked.style() === 'expand' || stacked.style() === 'stack_percent') {
+                        oldYTickFormat = yAxis.tickFormat();
+                        //Forces the yAxis to use percentage in 'expand' mode.
+                        yAxis.tickFormat(d3.format('%'));
+                    }
+                    else {
+                        if (oldYTickFormat) yAxis.tickFormat(oldYTickFormat);
+                    }
 
                 g.select('.nv-y.nv-axis')
                     .transition().duration(0)
@@ -447,8 +455,6 @@ nv.models.stackedAreaChart = function() {
     chart.xAxis = xAxis;
     chart.yAxis = yAxis;
     chart.interactiveLayer = interactiveLayer;
-
-    yAxis.setTickFormat = yAxis.tickFormat;
 
     chart.dispatch = dispatch;
     chart.options = nv.utils.optionsFunc.bind(chart);

--- a/test/mocha/stacked.coffee
+++ b/test/mocha/stacked.coffee
@@ -110,3 +110,10 @@ describe 'NVD3', ->
             chart.stacked.style().should.equal 'expand'
             newTickFormat = chart.yAxis.tickFormat()
             newTickFormat(1).should.equal '100%'
+
+            chart.dispatch.changeState
+                style: 'stacked'
+
+            chart.stacked.style().should.equal 'stacked'
+            newTickFormat = chart.yAxis.tickFormat()
+            newTickFormat(1).should.equal '<1>'


### PR DESCRIPTION
Pull Request #790 introduced another bug, where if you switch to 'Expanded'
    and then switch back to 'Stacked', the yAxis retains the percentage format.
    Fixed bug and added unit test.
