### PR TITLE
Proposal only!  Fix voronoi tooltips to show all siblings for duplicates

### DIFF
--- a/src/models/line.js
+++ b/src/models/line.js
@@ -48,9 +48,9 @@ nv.models.line = function() {
         renderWatch.reset();
         renderWatch.models(scatter);
         selection.each(function(data) {
-            var availableWidth = width - margin.left - margin.right,
-                availableHeight = height - margin.top - margin.bottom,
-                container = d3.select(this);
+            var container = d3.select(this);
+            var availableWidth = nv.utils.availableWidth(width, container, margin),
+                availableHeight = nv.utils.availableHeight(height, container, margin);
             nv.utils.initSVG(container);
 
             // Setup Scales

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -54,6 +54,13 @@ nv.models.lineChart = function() {
             y = yAxis.tickFormat()(lines.y()(e.point, e.pointIndex)),
             content = tooltip(e.series.key, x, y, e, chart);
 
+        if (e.sibs) {
+            for (var i = 0; i < e.sibs.length; i++) {
+                x = xAxis.tickFormat()(lines.x()(e.sibs[i].point, e.sibs[i].pointIndex)),
+                y = yAxis.tickFormat()(lines.y()(e.sibs[i].point, e.sibs[i].pointIndex)),
+                content += tooltip(e.sibs[i].series.key, x, y, e.sibs[i], chart);
+            }
+        }
         nv.tooltip.show([left, top], content, null, null, offsetElement);
     };
 

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -141,35 +141,34 @@ nv.models.scatter = function() {
             g.attr('clip-path', clipEdge ? 'url(#nv-edge-clip-' + id + ')' : '');
 
             function updateInteractiveLayer() {
+                // Always clear needs-update flag regardless of whether or not
+                // we will actually do anything (avoids needless invocations).
                 needsUpdate = false;
 
                 if (!interactive) return false;
 
-                var eventElements;
-
-                var vertices = d3.merge(data.map(function(group, groupIndex) {
-                        return group.values
-                            .map(function(point, pointIndex) {
-                                // *Adding noise to make duplicates very unlikely
-                                // *Injecting series and point index for reference
-                                /* *Adding a 'jitter' to the points, because there's an issue in d3.geom.voronoi.
-                                 */
-                                var pX = getX(point,pointIndex);
-                                var pY = getY(point,pointIndex);
-
-                                return [x(pX)+ Math.random() * 1e-7,
-                                        y(pY)+ Math.random() * 1e-7,
-                                    groupIndex,
-                                    pointIndex, point]; //temp hack to add noise until I think of a better way so there are no duplicates
-                            })
-                            .filter(function(pointArray, pointIndex) {
-                                return pointActive(pointArray[4], pointIndex); // Issue #237.. move filter to after map, so pointIndex is correct!
-                            })
-                    })
-                );
-
                 // inject series and point index for reference into voronoi
                 if (useVoronoi === true) {
+                    var vertices = d3.merge(data.map(function(group, groupIndex) {
+                            return group.values
+                                .map(function(point, pointIndex) {
+                                    // *Adding noise to make duplicates very unlikely
+                                    // *Injecting series and point index for reference
+                                    /* *Adding a 'jitter' to the points, because there's an issue in d3.geom.voronoi.
+                                     */
+                                    var pX = getX(point,pointIndex);
+                                    var pY = getY(point,pointIndex);
+
+                                    return [x(pX)+ Math.random() * 1e-7,
+                                            y(pY)+ Math.random() * 1e-7,
+                                        groupIndex,
+                                        pointIndex, point]; //temp hack to add noise until I think of a better way so there are no duplicates
+                                })
+                                .filter(function(pointArray, pointIndex) {
+                                    return pointActive(pointArray[4], pointIndex); // Issue #237.. move filter to after map, so pointIndex is correct!
+                                })
+                        })
+                    );
 
                     if (vertices.length == 0) return false;  // No active points, we're done
                     if (vertices.length < 3) {
@@ -272,17 +271,6 @@ nv.models.scatter = function() {
                         });
 
                 } else {
-                    /*
-                     // bring data in form needed for click handlers
-                     var dataWithPoints = vertices.map(function(d, i) {
-                     return {
-                     'data': d,
-                     'series': vertices[i][2],
-                     'point': vertices[i][3]
-                     }
-                     });
-                     */
-
                     // add event handlers to points instead voronoi paths
                     wrap.select('.nv-groups').selectAll('.nv-group')
                         .selectAll('.nv-point')

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -203,8 +203,18 @@ nv.models.scatter = function() {
                     pointPaths
                         .enter().append("svg:path")
                         .attr("d", function(d) {
-                            if (!d || !d.data || d.data.length === 0)
+                            if (!d) {
+                                console.log("!d M 0 0");
                                 return 'M 0 0';
+                            }
+                            else if (!d.data) {
+                                console.log("!d.data M 0 0");
+                                return 'M 0 0';
+                            }
+                            if (d.data.length === 0) {
+                                console.log("d.data.length==0 M 0 0");
+                                return 'M 0 0';
+                            }
                             else
                                 return "M" + d.data.join(",") + "Z";
                         })

--- a/src/utils.js
+++ b/src/utils.js
@@ -567,31 +567,79 @@ nv.utils.initSVG = function(svg) {
 Sanitize and provide default for the container height.
 */
 nv.utils.sanitizeHeight = function(height, container) {
-    return (height || parseInt(container.style('height')) || 400);
-};
+    if (height < 0) {
+        debugger;
+    }
+    if (height > 0) {
+        console.log("height = ", height);
+        return height;
+    }
+    else {
+        var ch = parseInt(container.style('height'));
+        if (ch > 0) {
+            console.log("ch = ", ch);
+            return ch;
+        }
+        else {
+            return 400;
+        }
+    }
+    //return ((height > 0 ? height : 0) || parseInt(container.style('height')) || 400);
+}
 
 
 /*
 Sanitize and provide default for the container width.
 */
 nv.utils.sanitizeWidth = function(width, container) {
-    return (width || parseInt(container.style('width')) || 960);
-};
+    if (width < 0) {
+        debugger;
+    }
+    if (width > 0) {
+        console.log("width = ", width);
+        return width;
+    }
+    else {
+        var cw = parseInt(container.style('width'));
+        if (cw > 0) {
+            console.log("cw = ", cw);
+            return cw;
+        }
+        else {
+            return 960;
+        }
+    }
+    //return ((width > 0 ? width : 0) || parseInt(container.style('width')) || 960);
+}
 
 
 /*
 Calculate the available height for a chart.
 */
 nv.utils.availableHeight = function(height, container, margin) {
-    return nv.utils.sanitizeHeight(height, container) - margin.top - margin.bottom;
-};
+    var h = nv.utils.sanitizeHeight(height, container) - margin.top - margin.bottom;
+    if (h <= 0) {
+        debugger;
+    }
+    else {
+        console.log("h = ", h);
+    }
+    return (h > 0 ? h : 0);
+}
 
 /*
 Calculate the available width for a chart.
 */
 nv.utils.availableWidth = function(width, container, margin) {
-    return nv.utils.sanitizeWidth(width, container) - margin.left - margin.right;
-};
+    var w = nv.utils.sanitizeWidth(width, container) - margin.left - margin.right;
+    if (w <= 0) {
+        debugger;
+    }
+    else {
+        console.log("w = ", w);
+    }
+    return (w > 0 ? w : 0);
+}
 
 /*
 Clear any rendered chart components and display a chart's 'noData' message


### PR DESCRIPTION
This is a proposal for a fix.  It solves the voronoi problem of duplicate points by eliminating them, but saving the duplicates as siblings that are also displayed in the tooltip.  This should solve problems like #330 once and for all.

For now, we only do that for `lineCharts`.

Please ignore the two debugging commits, and the base change to `lines.js`.