### PR TITLE
Fix donut chart labels.

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -77,11 +77,11 @@ nv.models.pie = function() {
             var arc = d3.svg.arc().outerRadius(arcRadius);
             var arcOver = d3.svg.arc().outerRadius(arcRadius + 5);
 
-            if (startAngle) {
+            if (startAngle !== false) {
                 arc.startAngle(startAngle);
                 arcOver.startAngle(startAngle);
             }
-            if (endAngle) {
+            if (endAngle !== false) {
                 arc.endAngle(endAngle);
                 arcOver.endAngle(endAngle);
             }

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -205,7 +205,9 @@ nv.models.pie = function() {
                 }
 
                 if (donutLabelsOutside) {
-                    labelsArc = d3.svg.arc().outerRadius(arc.outerRadius()).startAngle(startAngle).endAngle(endAngle);
+                    labelsArc = d3.svg.arc().outerRadius(arc.outerRadius());
+                    if (startAngle === false) labelsArc.startAngle(startAngle);
+                    if (endAngle === false) labelsArc.endAngle(endAngle);
                 }
 
                 pieLabels.enter().append("g").classed("nv-label",true).each(function(d,i) {

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -206,8 +206,8 @@ nv.models.pie = function() {
 
                 if (donutLabelsOutside) {
                     labelsArc = d3.svg.arc().outerRadius(arc.outerRadius());
-                    if (startAngle === false) labelsArc.startAngle(startAngle);
-                    if (endAngle === false) labelsArc.endAngle(endAngle);
+                    if (startAngle !== false) labelsArc.startAngle(startAngle);
+                    if (endAngle !== false) labelsArc.endAngle(endAngle);
                 }
 
                 pieLabels.enter().append("g").classed("nv-label",true).each(function(d,i) {


### PR DESCRIPTION
Fixes #801. Only set start and end angles if they're specified. Explicitly equate with `false` because `0` is a valid angle. `false`, on the other hand, is not a valid angle until it gets coerced to `0`. The problem was that the labels were being put on an arc of zero angular length.