### PR TITLE
Change pie/donut charts to use a mouse following tooltip

### DIFF
--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -390,13 +390,8 @@ as well as used to print out examples using those example inputs.
             default: true,
             examples: [true]
         },
-        donutLabelsOutside: {
-            desc: "Whether donut chart labels should be outside or inside the slices",
-            default: true,
-            examples: [true]
-        },
-        pieLabelsOutside: {
-            desc: "Whether pie chart labels should be outside or inside the slices",
+        labelsOutside: {
+            desc: "Whether pie/donut chart labels should be outside the slices instead of inside them",
             default: true,
             examples: [true]
         },

--- a/examples/pieChart.html
+++ b/examples/pieChart.html
@@ -86,11 +86,6 @@
             //.showLabels(false)
             .color(d3.scale.category20().range().slice(8))
             .growOnHover(false)
-            .tooltipContent(function(key, y, e, graph) {
-                return '<h3 style="padding: 5px; background-color: '
-                        + e.color + '"><strong>Yo, the value is</strong></h3>'
-                        + '<p style="padding:5px;">' +  y + '</p>';
-            })
             .width(width)
             .height(height);
 

--- a/src/core.js
+++ b/src/core.js
@@ -70,9 +70,9 @@ nv.log = function() {
 };
 
 // print console warning, should be used by deprecated functions
-nv.deprecated = function(name) {
-    if (nv.dev && console && console.warn) {
-        console.warn('`' + name + '` has been deprecated.');
+nv.deprecated = function(name, info) {
+    if (console && console.warn) {
+        console.warn('nvd3 warning: `' + name + '` has been deprecated. ', info || '');
     }
 };
 

--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -198,7 +198,6 @@ nv.models.pieChart = function() {
     });
 
     pie.dispatch.on('elementClick.tooltip', function(evt) {
-        console.log("caught click! ", evt);
         tooltip.html(tooltipContent(evt))
             .style('display', 'inline-block');
     });


### PR DESCRIPTION
Also cleaned up the code a little, and changed the labelsOutside options to just be a single option and added depreciated stubs for the old options that gives console warnings.  Also changed it so depreciated warnings show up even if not in dev mode since they're pretty important.

Current charts that override tooltipContent will see their tooltips break though.   There isn't a lot I can do about that since the way it was passing the data was stupid because it was picking out parts instead of just passing the whole event object.  