### PR TITLE
Issue #816:  lineWithFocusChart, fixing the 'wiggling'

### DIFF
--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -41,6 +41,7 @@ nv.models.lineWithFocusChart = function() {
 
     lines
         .clipEdge(true)
+        .duration(0)
     ;
     lines2
         .interactive(false)
@@ -228,11 +229,7 @@ nv.models.lineWithFocusChart = function() {
             brush
                 .x(x2)
                 .on('brush', function() {
-                    //When brushing, turn off transitions because chart needs to change immediately.
-                    var oldTransition = chart.duration();
-                    chart.duration(0);
                     onBrush();
-                    chart.duration(oldTransition);
                 });
 
             if (brushExtent) brush.extent(brushExtent);


### PR DESCRIPTION
Change the lines.duration to 0, to remove transitions and prevent weird things from happening when changing the focus area.

Issue #816 