### PR TITLE
[PREVIEW] Issue 515 margin top and legend fixes

### DIFF
--- a/examples/cumulativeLineChart.html
+++ b/examples/cumulativeLineChart.html
@@ -33,6 +33,7 @@
     // and may do more in the future... it's NOT required
     nv.addGraph(function() {
         var chart = nv.models.cumulativeLineChart()
+            .margin({top: 40})
             .useInteractiveGuideline(true)
             .x(function(d) { return d[0] })
             .y(function(d) { return d[1]/100 })

--- a/examples/lineChart.html
+++ b/examples/lineChart.html
@@ -44,8 +44,10 @@
     nv.addGraph(function() {
         chart = nv.models.lineChart()
             .options({
+                margin: {top: 30, bottom: 100},
+                showLegend: false,
                 transitionDuration: 300,
-                useInteractiveGuideline: true
+                useInteractiveGuideline: false
             })
         ;
 

--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -14,7 +14,7 @@ nv.models.cumulativeLineChart = function() {
         , interactiveLayer = nv.interactiveGuideline()
         ;
 
-    var margin = {top: 30, right: 30, bottom: 50, left: 60}
+    var margin = {top: 0, right: 30, bottom: 50, left: 60}
         , color = nv.utils.defaultColor()
         , width = null
         , height = null
@@ -111,6 +111,8 @@ nv.models.cumulativeLineChart = function() {
 
             var availableWidth = nv.utils.availableWidth(width, container, margin),
                 availableHeight = nv.utils.availableHeight(height, container, margin);
+
+            var marginTopActual = margin.top;
 
             chart.update = function() {
                 if (duration === 0)
@@ -231,13 +233,15 @@ nv.models.cumulativeLineChart = function() {
                     .datum(data)
                     .call(legend);
 
-                if ( margin.top != legend.height()) {
-                    margin.top = legend.height();
-                    availableHeight = nv.utils.availableHeight(height, container, margin);
-                }
+                marginTopActual = margin.top + legend.height();
+                availableHeight = nv.utils.availableHeight(
+                    height, 
+                    container, 
+                    {top: marginTopActual, bottom: margin.bottom}
+                );
 
                 g.select('.nv-legendWrap')
-                    .attr('transform', 'translate(0,' + (-margin.top) +')')
+                    .attr('transform', 'translate(0,' + (-legend.height()) +')')
             }
 
             // Controls
@@ -255,11 +259,11 @@ nv.models.cumulativeLineChart = function() {
 
                 g.select('.nv-controlsWrap')
                     .datum(controlsData)
-                    .attr('transform', 'translate(0,' + (-margin.top) +')')
+                    .attr('transform', 'translate(0,' + (-controls.height()) +')')
                     .call(controls);
             }
 
-            wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+            wrap.attr('transform', 'translate(' + margin.left + ',' + marginTopActual + ')');
 
             if (rightAlignYAxis) {
                 g.select(".nv-y.nv-axis")
@@ -283,7 +287,7 @@ nv.models.cumulativeLineChart = function() {
                 interactiveLayer
                     .width(availableWidth)
                     .height(availableHeight)
-                    .margin({left:margin.left,top:margin.top})
+                    .margin({left:margin.left,top:marginTopActual})
                     .svgContainer(container)
                     .xScale(x);
                 wrap.select(".nv-interactive").call(interactiveLayer);
@@ -484,7 +488,7 @@ nv.models.cumulativeLineChart = function() {
 
                 var xValue = xAxis.tickFormat()(chart.x()(singlePoint,pointIndex), pointIndex);
                 interactiveLayer.tooltip
-                    .position({left: pointXLocation + margin.left, top: e.mouseY + margin.top})
+                    .position({left: pointXLocation + margin.left, top: e.mouseY + marginTopActual})
                     .chartContainer(that.parentNode)
                     .enabled(tooltips)
                     .valueFormatter(function(d,i) {

--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -253,7 +253,7 @@ nv.models.cumulativeLineChart = function() {
 
                 g.select('.nv-controlsWrap')
                     .datum(controlsData)
-                    .attr('transform', 'translate(0,' + (-controls.height()) +')')
+                    .attr('transform', 'translate(0,' + (-legend.height()) +')')
                     .call(controls);
             }
 

--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -14,7 +14,7 @@ nv.models.cumulativeLineChart = function() {
         , interactiveLayer = nv.interactiveGuideline()
         ;
 
-    var margin = {top: 0, right: 30, bottom: 50, left: 60}
+    var margin = {top: 30, right: 30, bottom: 50, left: 60}
         , color = nv.utils.defaultColor()
         , width = null
         , height = null
@@ -225,24 +225,18 @@ nv.models.cumulativeLineChart = function() {
             gEnter.append('g').attr('class', 'nv-legendWrap');
             gEnter.append('g').attr('class', 'nv-controlsWrap');
 
-            // Legend
-            if (showLegend) {
-                legend.width(availableWidth);
+            // Legend creation logic.
+            var legendResult = nv.utils.createLegend(legend, {
+                showLegend: showLegend,
+                width: availableWidth,
+                height: availableHeight,
+                margin: margin,
+                data: data,
+                legendWrap: wrap.select('.nv-legendWrap')
+            });
 
-                g.select('.nv-legendWrap')
-                    .datum(data)
-                    .call(legend);
-
-                marginTopActual = margin.top + legend.height();
-                availableHeight = nv.utils.availableHeight(
-                    height, 
-                    container, 
-                    {top: marginTopActual, bottom: margin.bottom}
-                );
-
-                g.select('.nv-legendWrap')
-                    .attr('transform', 'translate(0,' + (-legend.height()) +')')
-            }
+            availableHeight = legendResult.availableHeight
+            marginTopActual = legendResult.marginTopActual
 
             // Controls
             if (showControls) {

--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -14,7 +14,7 @@ nv.models.cumulativeLineChart = function() {
         , interactiveLayer = nv.interactiveGuideline()
         ;
 
-    var margin = {top: 30, right: 30, bottom: 50, left: 60}
+    var margin = {top: 0, right: 30, bottom: 50, left: 60}
         , color = nv.utils.defaultColor()
         , width = null
         , height = null

--- a/src/models/historicalBarChart.js
+++ b/src/models/historicalBarChart.js
@@ -13,8 +13,7 @@ nv.models.historicalBarChart = function(bar_model) {
         , interactiveLayer = nv.interactiveGuideline()
         ;
 
-
-    var margin = {top: 30, right: 90, bottom: 50, left: 90}
+    var margin = {top: 0, right: 90, bottom: 50, left: 90}
         , color = nv.utils.defaultColor()
         , width = null
         , height = null
@@ -86,6 +85,8 @@ nv.models.historicalBarChart = function(bar_model) {
             var availableWidth = nv.utils.availableWidth(width, container, margin),
                 availableHeight = nv.utils.availableHeight(height, container, margin);
 
+            var marginTopActual = margin.top;
+
             chart.update = function() { container.transition().duration(transitionDuration).call(chart) };
             chart.container = this;
 
@@ -134,15 +135,18 @@ nv.models.historicalBarChart = function(bar_model) {
                     .datum(data)
                     .call(legend);
 
-                if ( margin.top != legend.height()) {
-                    margin.top = legend.height();
-                    availableHeight = nv.utils.availableHeight(height, container, margin);
-                }
+                marginTopActual = margin.top + legend.height();
 
+                availableHeight = nv.utils.availableHeight(
+                    height, 
+                    container, 
+                    {top:marginTopActual, bottom: margin.bottom}
+                );
+                
                 wrap.select('.nv-legendWrap')
-                    .attr('transform', 'translate(0,' + (-margin.top) +')')
+                    .attr('transform', 'translate(0,' + (-legend.height()) +')')
             }
-            wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+            wrap.attr('transform', 'translate(' + margin.left + ',' + marginTopActual + ')');
 
             if (rightAlignYAxis) {
                 g.select(".nv-y.nv-axis")
@@ -154,7 +158,7 @@ nv.models.historicalBarChart = function(bar_model) {
                 interactiveLayer
                     .width(availableWidth)
                     .height(availableHeight)
-                    .margin({left:margin.left, top:margin.top})
+                    .margin({left:margin.left, top:marginTopActual})
                     .svgContainer(container)
                     .xScale(x);
                 wrap.select(".nv-interactive").call(interactiveLayer);
@@ -225,7 +229,7 @@ nv.models.historicalBarChart = function(bar_model) {
 
                 var xValue = xAxis.tickFormat()(chart.x()(singlePoint,pointIndex));
                 interactiveLayer.tooltip
-                    .position({left: pointXLocation + margin.left, top: e.mouseY + margin.top})
+                    .position({left: pointXLocation + margin.left, top: e.mouseY + marginTopActual})
                     .chartContainer(that.parentNode)
                     .enabled(tooltips)
                     .valueFormatter(function(d,i) {

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -88,6 +88,7 @@ nv.models.lineChart = function() {
             nv.utils.initSVG(container);
             var availableWidth = nv.utils.availableWidth(width, container, margin),
                 availableHeight = nv.utils.availableHeight(height, container, margin);
+            var marginTopActual = margin.top;
 
             chart.update = function() {
                 if (duration === 0)
@@ -124,7 +125,6 @@ nv.models.lineChart = function() {
                 container.selectAll('.nv-noData').remove();
             }
 
-
             // Setup Scales
             x = lines.xScale();
             y = lines.yScale();
@@ -153,15 +153,19 @@ nv.models.lineChart = function() {
                     .datum(data)
                     .call(legend);
 
-                margin.top += legend.height();
+                marginTopActual = margin.top + legend.height();
 
-                availableHeight = nv.utils.availableHeight(height, container, margin);
+                availableHeight = nv.utils.availableHeight(
+                    height, 
+                    container, 
+                    {top: marginTopActual, bottom: margin.bottom}
+                );
 
                 wrap.select('.nv-legendWrap')
                     .attr('transform', 'translate(0,' + (-legend.height()) +')')
             }
 
-            wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+            wrap.attr('transform', 'translate(' + margin.left + ',' + marginTopActual + ')');
 
             if (rightAlignYAxis) {
                 g.select(".nv-y.nv-axis")
@@ -173,7 +177,7 @@ nv.models.lineChart = function() {
                 interactiveLayer
                     .width(availableWidth)
                     .height(availableHeight)
-                    .margin({left:margin.left, top:margin.top})
+                    .margin({left:margin.left, top:marginTopActual})
                     .svgContainer(container)
                     .xScale(x);
                 wrap.select(".nv-interactive").call(interactiveLayer);
@@ -259,7 +263,7 @@ nv.models.lineChart = function() {
 
                 var xValue = xAxis.tickFormat()(chart.x()(singlePoint,pointIndex));
                 interactiveLayer.tooltip
-                    .position({left: pointXLocation + margin.left, top: e.mouseY + margin.top})
+                    .position({left: pointXLocation + margin.left, top: e.mouseY + marginTopActual})
                     .chartContainer(that.parentNode)
                     .enabled(tooltips)
                     .valueFormatter(function(d,i) {

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -145,25 +145,18 @@ nv.models.lineChart = function() {
                 .attr("width",availableWidth)
                 .attr("height",(availableHeight > 0) ? availableHeight : 0);
 
-            // Legend
-            if (showLegend) {
-                legend.width(availableWidth);
+            // Legend creation logic.
+            var legendResult = nv.utils.createLegend(legend, {
+                showLegend: showLegend,
+                width: availableWidth,
+                height: availableHeight,
+                margin: margin,
+                data: data,
+                legendWrap: wrap.select('.nv-legendWrap')
+            });
 
-                g.select('.nv-legendWrap')
-                    .datum(data)
-                    .call(legend);
-
-                marginTopActual = margin.top + legend.height();
-
-                availableHeight = nv.utils.availableHeight(
-                    height, 
-                    container, 
-                    {top: marginTopActual, bottom: margin.bottom}
-                );
-
-                wrap.select('.nv-legendWrap')
-                    .attr('transform', 'translate(0,' + (-legend.height()) +')')
-            }
+            availableHeight = legendResult.availableHeight
+            marginTopActual = legendResult.marginTopActual
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + marginTopActual + ')');
 

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -12,7 +12,7 @@ nv.models.lineChart = function() {
         , interactiveLayer = nv.interactiveGuideline()
         ;
 
-    var margin = {top: 30, right: 20, bottom: 50, left: 60}
+    var margin = {top: 0, right: 20, bottom: 50, left: 60}
         , color = nv.utils.defaultColor()
         , width = null
         , height = null
@@ -153,13 +153,12 @@ nv.models.lineChart = function() {
                     .datum(data)
                     .call(legend);
 
-                if ( margin.top != legend.height()) {
-                    margin.top = legend.height();
-                    availableHeight = nv.utils.availableHeight(height, container, margin);
-                }
+                margin.top += legend.height();
+
+                availableHeight = nv.utils.availableHeight(height, container, margin);
 
                 wrap.select('.nv-legendWrap')
-                    .attr('transform', 'translate(0,' + (-margin.top) +')')
+                    .attr('transform', 'translate(0,' + (-legend.height()) +')')
             }
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');

--- a/src/utils.js
+++ b/src/utils.js
@@ -598,6 +598,38 @@ nv.utils.availableWidth = function(width, container, margin) {
 };
 
 /*
+The logic for positioning the legend on all charts is the same.
+This utility factors out that logic.
+*/
+nv.utils.createLegend = function(legend, options) {
+    var margin = options.margin;
+    var marginTopActual = margin.top;
+    var minMarginTop = 30; //minimum margin top.
+    var availableHeight;
+    if (options.showLegend) {
+        legend.width(options.width);
+
+        options.legendWrap
+            .datum(options.data)
+            .call(legend);
+
+        marginTopActual = margin.top + legend.height();
+
+        options.legendWrap.attr('transform', 'translate(0,' + (-legend.height()) +')');
+    }
+    marginTopActual = d3.max([minMarginTop, marginTopActual]);
+    availableHeight = nv.utils.availableHeight(
+        options.height,
+        null, 
+        {top: marginTopActual, bottom: margin.bottom}
+    );
+    return {
+        marginTopActual: marginTopActual,
+        availableHeight: availableHeight
+    };
+};
+
+/*
 Clear any rendered chart components and display a chart's 'noData' message
 */
 nv.utils.noData = function(chart, container) {

--- a/test/mocha/cumulative-line.coffee
+++ b/test/mocha/cumulative-line.coffee
@@ -77,7 +77,7 @@ describe 'NVD3', ->
 
         it 'has the element with .nv-cumulativeLine class right positioned', ->
           cumulativeLine = builder1.$ 'g.nvd3.nv-cumulativeLine'
-          cumulativeLine[0].getAttribute('transform').should.be.equal "translate(40,30)"
+          cumulativeLine[0].getAttribute('transform').should.be.equal "translate(40,40)"
 
         it 'clears chart objects for no data', ->
             builder = new ChartBuilder nv.models.cumulativeLineChart()
@@ -85,6 +85,25 @@ describe 'NVD3', ->
             
             groups = builder.$ 'g'
             groups.length.should.equal 0, 'removes chart components'
+
+        it 'can set margin.top', ->
+            builder1.model.showLegend(true);
+            builder1.model.margin({top: 100});
+            builder1.model.update();
+            getTransform = (elem)-> elem[0].getAttribute 'transform'
+
+            wrap = builder1.$ '.nv-wrap.nv-cumulativeLine'
+            getTransform(wrap).should.equal 'translate(40,130)'
+
+            legend = builder1.$ '.nv-legendWrap'
+            getTransform(legend).should.equal 'translate(0,-30)'
+
+            controls = builder1.$ '.nv-controlsWrap'
+            getTransform(controls).should.equal 'translate(0,-30)'
+
+            builder1.model.update()
+            wrap = builder1.$ '.nv-wrap.nv-cumulativeLine'
+            getTransform(wrap).should.equal 'translate(40,130)'
 
         it 'has correct structure', ->
           cssClasses = [
@@ -118,17 +137,6 @@ describe 'NVD3', ->
 
           afterEach ->
             builder.teardown()
-
-          # todo: ideally it should work, but...
-          xit 'margin', ->
-            options =
-              margin:
-                top: 10
-                right: 20
-                bottom: 30
-                left: 40
-            builder.build options, sampleData
-            builder.$(".nv-cumulativeLine")[0].getAttribute('transform').should.be.equal "translate(40,10)"
 
           it "color", ->
             options.color = -> "#000000"
@@ -195,36 +203,6 @@ describe 'NVD3', ->
               options.useInteractiveGuideline = false
               builder.build options, sampleData
               builder.$(".nv-cumulativeLine .nv-interactiveLineLayer").should.have.length 0
-
-          # todo: pass this
-          describe 'tooltips', ->
-            xit "true", ->
-              options.tooltips = true
-              builder.build options, sampleData
-              builder.model.interactiveLayer.dispatch.elementMousemove eventTooltipData
-              tooltip = document.querySelector '.nvtooltip'
-              should.exist tooltip
-
-            xit "false", ->
-              options.tooltips = false
-              builder.build options, sampleData
-              builder.model.interactiveLayer.dispatch.elementMousemove eventTooltipData
-              tooltip = document.querySelector '.nvtooltip'
-              should.not.exist tooltip
-
-          # todo: pass this
-          describe "noErrorCheck", ->
-            xit "true", ->
-              options.noErrorCheck = true
-              builder.build options, sampleData
-            xit "false", ->
-              options.noErrorCheck = false
-              builder.build options, sampleData
-            xit "tooltipContent", ->
-              options.tooltipContent = (key,x,y)-> "<h2>#{key}</h2>"
-              builder.build options, sampleData
-              # show a tooltip
-              expect(builder.$(".nv-cumulativeLine .nv-tooltip")).to.contain "<h2>#{sampleData1[0].key}</h2>"
 
           it "noData", ->
             options.noData = "error error"

--- a/test/mocha/historical-bar.coffee
+++ b/test/mocha/historical-bar.coffee
@@ -71,3 +71,20 @@ describe 'NVD3', ->
             builder.model.update()
             builder.model.xAxis.ticks().should.equal 34
             builder.model.yAxis.ticks().should.equal 56
+
+        it 'can set margin.top', ->
+            builder.model.showLegend(true);
+            builder.model.margin({top: 100});
+            builder.model.update();
+            getTransform = (elem)-> elem[0].getAttribute 'transform'
+
+            wrap = builder.$ '.nv-wrap.nv-historicalBarChart'
+            getTransform(wrap).should.equal 'translate(75,130)'
+
+            legend = builder.$ '.nv-legendWrap'
+            getTransform(legend).should.equal 'translate(0,-30)'
+
+            builder.model.update()
+            wrap = builder.$ '.nv-wrap.nv-historicalBarChart'
+            getTransform(wrap).should.equal 'translate(75,130)'
+            

--- a/test/mocha/line.coffee
+++ b/test/mocha/line.coffee
@@ -145,11 +145,14 @@ describe 'NVD3', ->
             builder.model.showLegend(true);
             builder.model.margin({top: 100});
             builder.model.update();
+            getTransform = (elem)-> elem[0].getAttribute 'transform'
 
             wrap = builder.$ '.nv-wrap.nv-lineChart'
-            transform = wrap[0].getAttribute 'transform'
-            transform.should.equal 'translate(75,130)'
+            getTransform(wrap).should.equal 'translate(75,130)'
 
             legend = builder.$ '.nv-legendWrap'
-            transform = legend[0].getAttribute 'transform'
-            transform.should.equal 'translate(0,-30)'
+            getTransform(legend).should.equal 'translate(0,-30)'
+
+            builder.model.update()
+            wrap = builder.$ '.nv-wrap.nv-lineChart'
+            getTransform(wrap).should.equal 'translate(75,130)'

--- a/test/mocha/line.coffee
+++ b/test/mocha/line.coffee
@@ -69,6 +69,8 @@ describe 'NVD3', ->
         afterEach ->
             builder.teardown()
 
+        getTransform = (elem)-> elem[0].getAttribute 'transform'
+
         it 'api check', ->
             should.exist builder.model.options, 'options exposed'
             for opt of options
@@ -141,11 +143,10 @@ describe 'NVD3', ->
             builder.model.xAxis.ticks().should.equal 34
             builder.model.yAxis.ticks().should.equal 56
 
-        it 'can set margin.top', ->
-            builder.model.showLegend(true);
-            builder.model.margin({top: 100});
-            builder.model.update();
-            getTransform = (elem)-> elem[0].getAttribute 'transform'
+        it 'can set margin.top and legend position', ->
+            builder.model.showLegend true
+            builder.model.margin {top: 100}
+            builder.model.update()
 
             wrap = builder.$ '.nv-wrap.nv-lineChart'
             getTransform(wrap).should.equal 'translate(75,130)'
@@ -156,3 +157,34 @@ describe 'NVD3', ->
             builder.model.update()
             wrap = builder.$ '.nv-wrap.nv-lineChart'
             getTransform(wrap).should.equal 'translate(75,130)'
+
+        it 'do not allow margin 0 to clip legend', ->
+            builder.model.showLegend true
+            builder.model.margin {top: 0}
+            builder.model.update()
+            wrap = builder.$ '.nv-wrap.nv-lineChart'
+            getTransform(wrap).should.equal 'translate(75,30)'
+
+        it 'defaults to reasonable margin.top if no legend', ->
+            builder2 = new ChartBuilder nv.models.lineChart()
+            opts = 
+                showLegend: false
+
+            builder2.build opts, sampleData1
+
+            wrap = builder2.$ '.nv-wrap.nv-lineChart'
+            getTransform(wrap).should.equal 'translate(60,30)'
+
+            builder2.teardown()
+
+        it 'defaults to reasonable margin.top if show legend', ->
+            builder2 = new ChartBuilder nv.models.lineChart()
+            opts = 
+                showLegend: true
+
+            builder2.build opts, sampleData1
+
+            wrap = builder2.$ '.nv-wrap.nv-lineChart'
+            getTransform(wrap).should.equal 'translate(60,30)'
+
+            builder2.teardown()

--- a/test/mocha/line.coffee
+++ b/test/mocha/line.coffee
@@ -140,3 +140,16 @@ describe 'NVD3', ->
             builder.model.update()
             builder.model.xAxis.ticks().should.equal 34
             builder.model.yAxis.ticks().should.equal 56
+
+        it 'can set margin.top', ->
+            builder.model.showLegend(true);
+            builder.model.margin({top: 100});
+            builder.model.update();
+
+            wrap = builder.$ '.nv-wrap.nv-lineChart'
+            transform = wrap[0].getAttribute 'transform'
+            transform.should.equal 'translate(75,130)'
+
+            legend = builder.$ '.nv-legendWrap'
+            transform = legend[0].getAttribute 'transform'
+            transform.should.equal 'translate(0,-30)'


### PR DESCRIPTION
Issue #515 brought to attention a glaring problem where setting margin.top doesn't actually do anything.  It's because showLegend logic overrides margin.top with the legend.height().

This PR attempts to fix that, while also factoring out the legend setup logic to a separate utility. 