### PR TITLE
Pie title supports resizing.

### DIFF
--- a/examples/donutChart.html
+++ b/examples/donutChart.html
@@ -18,6 +18,11 @@
             height: 350px !important;
             width: 350px !important;
         }
+		#test3 {
+			height: 500px !important;
+            width: 500px !important;
+		}
+		
         html, body {
             margin: 0px;
             padding: 0px;
@@ -30,7 +35,6 @@
         }
 
         .nvd3.nv-pie.nv-chart-donut1 .nv-pie-title {
-            font-size: 45px;
             opacity: 0.4;
             fill: rgba(224, 116, 76, 0.91);
         }
@@ -39,9 +43,13 @@
 </head>
 <body class='with-3d-shadow with-transitions'>
 
+<svg id="test3" class="mypiechart"></svg>
+
 <svg id="test1" class="mypiechart"></svg>
 
 <svg id="test2" class="mypiechart"></svg>
+
+
 
 <script>
 
@@ -82,7 +90,7 @@
         return chart;
 
     });
-
+	
     nv.addGraph(function() {
         var chart = nv.models.pieChart()
             .x(function(d) { return d.key })
@@ -111,6 +119,31 @@
             .call(chart);
 
         return chart;
+    });
+	
+	nv.addGraph(function() {
+        var chart = nv.models.pieChart()
+            .x(function(d) { return d.key })
+            .y(function(d) { return d.y })
+            .donut(true)
+            .width(width)
+            .height(height)
+            .padAngle(.08)
+            .cornerRadius(5)
+            .id('donut1'); // allow custom CSS for this one svg
+
+        chart.title("100%");
+        chart.pie.donutLabelsOutside(true).donut(true);
+
+        d3.select("#test3")
+            .datum(testdata)
+            .transition().duration(1200)
+            .attr('width', width)
+            .attr('height', height)
+            .call(chart);
+
+        return chart;
+
     });
 
 </script>

--- a/examples/donutChart.html
+++ b/examples/donutChart.html
@@ -18,11 +18,12 @@
             height: 350px !important;
             width: 350px !important;
         }
-		#test3 {
-			height: 500px !important;
+
+        #test3 {
+            height: 500px !important;
             width: 500px !important;
-		}
-		
+        }
+
         html, body {
             margin: 0px;
             padding: 0px;

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -111,7 +111,7 @@ nv.models.pie = function() {
                     .text(function (d) {
                         return title;
                     })
-                    .style("font-size", Math.min(availableWidth, availableHeight) / 6 + "px")
+                    .style("font-size", (Math.min(availableWidth, availableHeight)) * donutRatio * 2 / (title.length + 2) + "px")
                     .attr("dy", "0.35em") // trick to vertically center text
                     .attr('transform', function(d, i) {
                         return 'translate(0, '+ titleOffset + ')';

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -104,14 +104,14 @@ nv.models.pie = function() {
 
             // if title is specified and donut, put it in the middle
             if (donut && title) {
-                var title_g = g_pie.append('g').attr('class', 'nv-pie');
+                g_pie.append("text").attr('class', 'nv-pie-title');
 
-                title_g.append("text")
+                wrap.select('.nv-pie-title')
                     .style("text-anchor", "middle")
-                    .attr('class', 'nv-pie-title')
                     .text(function (d) {
                         return title;
                     })
+                    .style("font-size", Math.min(availableWidth, availableHeight) / 6 + "px")
                     .attr("dy", "0.35em") // trick to vertically center text
                     .attr('transform', function(d, i) {
                         return 'translate(0, '+ titleOffset + ')';


### PR DESCRIPTION
Adjust automatically the font-size of the title, with respect to the current donut chart size.

- It's not necessary to define a size in a css.
- It supports resizing.
- it depends on the title length
- it takes into account the donut ratio.