### PR TITLE
Change getColor() method to use Array.isArray() instead of instanceof… …

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -67,7 +67,8 @@ nv.utils.getColor = function(color) {
         return nv.utils.defaultColor();
 
     //if passed an array, turn it into a color scale
-    } else if(color instanceof Array) {
+    // use isArray, instanceof fails if d3 range is created in an iframe
+    } else if(Array.isArray(color)) {
         var color_scale = d3.scale.ordinal().range(color);
         return function(d, i) {
             var key = i === undefined ? d : i;


### PR DESCRIPTION
instanceof fails if the Array was created in an iframe due to the prototype chain having a different root.

This fixes https://github.com/novus/nvd3/issues/854

Array.isArray() is defined for our target browsers:   http://kangax.github.io/compat-table/es5/#Array.isArray