### PR TITLE
Basic support in touch browser

### DIFF
--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -141,6 +141,7 @@ nv.interactiveGuideline = function() {
             }
 
             svgContainer
+                .on("touchmove",mouseHandler)
                 .on("mousemove",mouseHandler, true)
                 .on("mouseout" ,mouseHandler,true)
                 .on("dblclick" ,mouseHandler)

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -249,8 +249,9 @@
                         // using tween since some versions of d3 can't auto-tween a translate on a div
                         .styleTween('transform', function (d) {
                             return translateInterpolator;
-                        })
-                        // not using tween for webkit touch device
+                        }, 'important')
+                        // Safari has its own `-webkit-transform` and does not support `transform` 
+                        // transform tooltip without transition only in Safari
                         .style('-webkit-transform', new_translate)
                         .style('opacity', 1);
                 }

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -250,6 +250,8 @@
                         .styleTween('transform', function (d) {
                             return translateInterpolator;
                         })
+                        // not using tween for webkit touch device
+                        .style('-webkit-transform', new_translate)
                         .style('opacity', 1);
                 }
 


### PR DESCRIPTION
- Enable interactiveLayer mouseHandler on touch event
- Fixed position of tooltip in touch browser, because webkit does not support `transform` which makes tooltips to appear on the top left corner