### PR TITLE
ParallelCoordinate support missing values.

### DIFF
--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -765,6 +765,11 @@ as well as used to print out examples using those example inputs.
             default: "[]",
             examples: [["axis1", "axis2", "axis3"]]
         },
+		dimensionFormats: {
+            desc: "D3 format for each x axis",
+            default: "Use the default formatter scale.tickFormat",
+            examples: [["%", "", "0.2f"]]
+        },
         gravity: {
             desc: "Can be 'n','s','e','w'. Determines how tooltip is positioned.",
             default: "w",

--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -756,6 +756,15 @@ as well as used to print out examples using those example inputs.
             desc: "Specifies each line tension. Values between 0 and 1.",
             default: 1,
             examples: [0.85]
+        },
+        dimensions: {
+            desc: "Deprecated. Use dimensionsNames instead. "
+        },
+        dimensionNames: {
+            desc: "Name of each dimension, used for each axis.",
+            default: "[]",
+            examples: [["axis1", "axis2", "axis3"]]
+        },
         gravity: {
             desc: "Can be 'n','s','e','w'. Determines how tooltip is positioned.",
             default: "w",

--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -765,7 +765,7 @@ as well as used to print out examples using those example inputs.
             default: "[]",
             examples: [["axis1", "axis2", "axis3"]]
         },
-		dimensionFormats: {
+        dimensionFormats: {
             desc: "D3 format for each x axis",
             default: "Use the default formatter scale.tickFormat",
             examples: [["%", "", "0.2f"]]

--- a/examples/parallelCoordinates.html
+++ b/examples/parallelCoordinates.html
@@ -35,7 +35,7 @@ nv.addGraph(function() {
 
     chart = nv.models.parallelCoordinates()
         .dimensionNames(["economy (mpg)", "cylinders", "displacement (cc)", "power (hp)", "weight (lb)", "0-60 mph (s)", "year"])
-		.lineTension(0.85);
+        .lineTension(0.85);
 		
 
     d3.select('#chart1 svg')

--- a/examples/parallelCoordinates.html
+++ b/examples/parallelCoordinates.html
@@ -12,9 +12,6 @@
         }
         svg {
             display: block;
-            float: left;
-            height: 450px !important;
-            width: 850px !important;
         }
         html, body, #chart1, svg {
             margin: 0px;

--- a/examples/parallelCoordinates.html
+++ b/examples/parallelCoordinates.html
@@ -35,8 +35,8 @@ nv.addGraph(function() {
 
     chart = nv.models.parallelCoordinates()
         .dimensionNames(["economy (mpg)", "cylinders", "displacement (cc)", "power (hp)", "weight (lb)", "0-60 mph (s)", "year"])
-		.dimensionFormats(["0.5f", "e", "g", "d", "", "%", "p"])
-		.lineTension(0.85);
+        .dimensionFormats(["0.5f", "e", "g", "d", "", "%", "p"])
+        .lineTension(0.85);
 		
 
     d3.select('#chart1 svg')

--- a/examples/parallelCoordinates.html
+++ b/examples/parallelCoordinates.html
@@ -12,6 +12,9 @@
         }
         svg {
             display: block;
+			float: left;
+			height: 450px !important;
+            width: 850px !important;
         }
         html, body, #chart1, svg {
             margin: 0px;
@@ -24,10 +27,8 @@
 </head>
 <body>
 
-<div id="chart1" class="chart">
-    <svg></svg>
-</div>
-
+<svg id="chart1" class="chart"></svg>
+<svg id="chart2" class="chart"></svg>
 <script>
 
 var chart;
@@ -37,10 +38,7 @@ nv.addGraph(function() {
         .dimensions(["economy (mpg)", "cylinders", "displacement (cc)", "power (hp)", "weight (lb)", "0-60 mph (s)", "year"])
         .lineTension(0.85);
 
-    // make all lines the same color like this
-    //chart.color(['steelblue']);
-
-    d3.select('#chart1 svg')
+    d3.select('#chart1')
             .datum(data())
             .call(chart);
 
@@ -49,6 +47,49 @@ nv.addGraph(function() {
     return chart;
 });
 
+nv.addGraph(function() {
+
+    chart = nv.models.parallelCoordinates()
+        .dimensionNames(["economy (mpg)", "cylinders", "displacement (cc)", "power (hp)", "weight (lb)", "0-60 mph (s)", "year"]);
+        
+
+    // make all lines the same color like this
+    chart.color(['steelblue']);
+
+    d3.select('#chart2')
+            .datum(data1())
+            .call(chart);
+
+    nv.utils.windowResize(chart.update);
+
+    return chart;
+});
+
+function data1() {
+    return [
+        {
+            "name": "AMC Ambassador Brougham",
+            "economy (mpg)": "13",
+            "cylinders": "x",
+            "displacement (cc)": "s",
+            "power (hp)": "177",
+            "weight (lb)": "f",
+            "0-60 mph (s)": "11",
+            "year": ""
+        },
+
+		{
+            "name": "AMC Ambassador Brougham",
+            "economy (mpg)": "10",
+            "cylinders": "19",
+            "displacement (cc)": "36",
+            "power (hp)": "76",
+            "weight (lb)": "382",
+            "0-60 mph (s)": "120",
+            "year": "4"
+        }
+	]
+}
 function data() {
     return [
         {
@@ -106,7 +147,7 @@ function data() {
             "economy (mpg)": "23",
             "cylinders": "4",
             "displacement (cc)": "151",
-            "power (hp)": "",
+            "power (hp)": "0",
             "weight (lb)": "3035",
             "0-60 mph (s)": "20.5",
             "year": "82"
@@ -313,7 +354,7 @@ function data() {
         },
         {
             "name": "AMC Rebel SST (Wagon)",
-            "economy (mpg)": "",
+            "economy (mpg)": "0",
             "cylinders": "8",
             "displacement (cc)": "360",
             "power (hp)": "175",
@@ -713,7 +754,7 @@ function data() {
         },
         {
             "name": "Chevrolet Chevelle Concours (Wagon)",
-            "economy (mpg)": "",
+            "economy (mpg)": "0",
             "cylinders": "8",
             "displacement (cc)": "350",
             "power (hp)": "165",
@@ -1163,7 +1204,7 @@ function data() {
         },
         {
             "name": "Citroen DS-21 Pallas",
-            "economy (mpg)": "",
+            "economy (mpg)": "0",
             "cylinders": "4",
             "displacement (cc)": "133",
             "power (hp)": "115",
@@ -2086,7 +2127,7 @@ function data() {
             "economy (mpg)": "21",
             "cylinders": "6",
             "displacement (cc)": "200",
-            "power (hp)": "",
+            "power (hp)": "0",
             "weight (lb)": "2875",
             "0-60 mph (s)": "17",
             "year": "74"
@@ -2113,7 +2154,7 @@ function data() {
         },
         {
             "name": "Ford Mustang Boss 302",
-            "economy (mpg)": "",
+            "economy (mpg)": "0",
             "cylinders": "8",
             "displacement (cc)": "302",
             "power (hp)": "140",
@@ -2126,7 +2167,7 @@ function data() {
             "economy (mpg)": "23.6",
             "cylinders": "4",
             "displacement (cc)": "140",
-            "power (hp)": "",
+            "power (hp)": "0",
             "weight (lb)": "2905",
             "0-60 mph (s)": "14.3",
             "year": "80"
@@ -2226,7 +2267,7 @@ function data() {
             "economy (mpg)": "25",
             "cylinders": "4",
             "displacement (cc)": "98",
-            "power (hp)": "",
+            "power (hp)": "0",
             "weight (lb)": "2046",
             "0-60 mph (s)": "19",
             "year": "71"
@@ -2273,7 +2314,7 @@ function data() {
         },
         {
             "name": "Ford Torino (Wagon)",
-            "economy (mpg)": "",
+            "economy (mpg)": "0",
             "cylinders": "8",
             "displacement (cc)": "351",
             "power (hp)": "153",
@@ -3143,7 +3184,7 @@ function data() {
         },
         {
             "name": "Plymouth Satellite (Wagon)",
-            "economy (mpg)": "",
+            "economy (mpg)": "0",
             "cylinders": "8",
             "displacement (cc)": "383",
             "power (hp)": "175",
@@ -3436,7 +3477,7 @@ function data() {
             "economy (mpg)": "34.5",
             "cylinders": "4",
             "displacement (cc)": "100",
-            "power (hp)": "",
+            "power (hp)": "0",
             "weight (lb)": "2320",
             "0-60 mph (s)": "15.8",
             "year": "81"
@@ -3456,14 +3497,14 @@ function data() {
             "economy (mpg)": "40.9",
             "cylinders": "4",
             "displacement (cc)": "85",
-            "power (hp)": "",
+            "power (hp)": "0",
             "weight (lb)": "1835",
             "0-60 mph (s)": "17.3",
             "year": "80"
         },
         {
             "name": "Saab 900S",
-            "economy (mpg)": "",
+            "economy (mpg)": "0",
             "cylinders": "4",
             "displacement (cc)": "121",
             "power (hp)": "110",
@@ -4023,7 +4064,7 @@ function data() {
         },
         {
             "name": "Volkswagen Super Beetle 117",
-            "economy (mpg)": "",
+            "economy (mpg)": "0",
             "cylinders": "4",
             "displacement (cc)": "97",
             "power (hp)": "48",

--- a/examples/parallelCoordinates.html
+++ b/examples/parallelCoordinates.html
@@ -12,8 +12,8 @@
         }
         svg {
             display: block;
-			float: left;
-			height: 450px !important;
+	    float: left;
+	    height: 450px !important;
             width: 850px !important;
         }
         html, body, #chart1, svg {

--- a/examples/parallelCoordinates.html
+++ b/examples/parallelCoordinates.html
@@ -24,18 +24,20 @@
 </head>
 <body>
 
-<svg id="chart1" class="chart"></svg>
-<svg id="chart2" class="chart"></svg>
+<div id="chart1" class="chart">
+    <svg></svg>
+</div>
+
 <script>
 
 var chart;
 nv.addGraph(function() {
 
     chart = nv.models.parallelCoordinates()
-        .dimensions(["economy (mpg)", "cylinders", "displacement (cc)", "power (hp)", "weight (lb)", "0-60 mph (s)", "year"])
-        .lineTension(0.85);
+        .dimensionNames(["economy (mpg)", "cylinders", "displacement (cc)", "power (hp)", "weight (lb)", "0-60 mph (s)", "year"]);
 
-    d3.select('#chart1')
+
+    d3.select('#chart1 svg')
             .datum(data())
             .call(chart);
 
@@ -44,49 +46,6 @@ nv.addGraph(function() {
     return chart;
 });
 
-nv.addGraph(function() {
-
-    chart = nv.models.parallelCoordinates()
-        .dimensionNames(["economy (mpg)", "cylinders", "displacement (cc)", "power (hp)", "weight (lb)", "0-60 mph (s)", "year"]);
-        
-
-    // make all lines the same color like this
-    chart.color(['steelblue']);
-
-    d3.select('#chart2')
-            .datum(data1())
-            .call(chart);
-
-    nv.utils.windowResize(chart.update);
-
-    return chart;
-});
-
-function data1() {
-    return [
-        {
-            "name": "AMC Ambassador Brougham",
-            "economy (mpg)": "13",
-            "cylinders": "x",
-            "displacement (cc)": "s",
-            "power (hp)": "177",
-            "weight (lb)": "f",
-            "0-60 mph (s)": "11",
-            "year": ""
-        },
-
-		{
-            "name": "AMC Ambassador Brougham",
-            "economy (mpg)": "10",
-            "cylinders": "19",
-            "displacement (cc)": "36",
-            "power (hp)": "76",
-            "weight (lb)": "382",
-            "0-60 mph (s)": "120",
-            "year": "4"
-        }
-	]
-}
 function data() {
     return [
         {
@@ -144,7 +103,7 @@ function data() {
             "economy (mpg)": "23",
             "cylinders": "4",
             "displacement (cc)": "151",
-            "power (hp)": "0",
+            "power (hp)": "",
             "weight (lb)": "3035",
             "0-60 mph (s)": "20.5",
             "year": "82"
@@ -351,7 +310,7 @@ function data() {
         },
         {
             "name": "AMC Rebel SST (Wagon)",
-            "economy (mpg)": "0",
+            "economy (mpg)": "",
             "cylinders": "8",
             "displacement (cc)": "360",
             "power (hp)": "175",
@@ -751,7 +710,7 @@ function data() {
         },
         {
             "name": "Chevrolet Chevelle Concours (Wagon)",
-            "economy (mpg)": "0",
+            "economy (mpg)": "",
             "cylinders": "8",
             "displacement (cc)": "350",
             "power (hp)": "165",
@@ -1201,7 +1160,7 @@ function data() {
         },
         {
             "name": "Citroen DS-21 Pallas",
-            "economy (mpg)": "0",
+            "economy (mpg)": "",
             "cylinders": "4",
             "displacement (cc)": "133",
             "power (hp)": "115",
@@ -2124,7 +2083,7 @@ function data() {
             "economy (mpg)": "21",
             "cylinders": "6",
             "displacement (cc)": "200",
-            "power (hp)": "0",
+            "power (hp)": "",
             "weight (lb)": "2875",
             "0-60 mph (s)": "17",
             "year": "74"
@@ -2151,7 +2110,7 @@ function data() {
         },
         {
             "name": "Ford Mustang Boss 302",
-            "economy (mpg)": "0",
+            "economy (mpg)": "",
             "cylinders": "8",
             "displacement (cc)": "302",
             "power (hp)": "140",
@@ -2164,7 +2123,7 @@ function data() {
             "economy (mpg)": "23.6",
             "cylinders": "4",
             "displacement (cc)": "140",
-            "power (hp)": "0",
+            "power (hp)": "",
             "weight (lb)": "2905",
             "0-60 mph (s)": "14.3",
             "year": "80"
@@ -2264,7 +2223,7 @@ function data() {
             "economy (mpg)": "25",
             "cylinders": "4",
             "displacement (cc)": "98",
-            "power (hp)": "0",
+            "power (hp)": "",
             "weight (lb)": "2046",
             "0-60 mph (s)": "19",
             "year": "71"
@@ -2311,7 +2270,7 @@ function data() {
         },
         {
             "name": "Ford Torino (Wagon)",
-            "economy (mpg)": "0",
+            "economy (mpg)": "",
             "cylinders": "8",
             "displacement (cc)": "351",
             "power (hp)": "153",
@@ -3181,7 +3140,7 @@ function data() {
         },
         {
             "name": "Plymouth Satellite (Wagon)",
-            "economy (mpg)": "0",
+            "economy (mpg)": "",
             "cylinders": "8",
             "displacement (cc)": "383",
             "power (hp)": "175",
@@ -3474,7 +3433,7 @@ function data() {
             "economy (mpg)": "34.5",
             "cylinders": "4",
             "displacement (cc)": "100",
-            "power (hp)": "0",
+            "power (hp)": "",
             "weight (lb)": "2320",
             "0-60 mph (s)": "15.8",
             "year": "81"
@@ -3494,14 +3453,14 @@ function data() {
             "economy (mpg)": "40.9",
             "cylinders": "4",
             "displacement (cc)": "85",
-            "power (hp)": "0",
+            "power (hp)": "",
             "weight (lb)": "1835",
             "0-60 mph (s)": "17.3",
             "year": "80"
         },
         {
             "name": "Saab 900S",
-            "economy (mpg)": "0",
+            "economy (mpg)": "",
             "cylinders": "4",
             "displacement (cc)": "121",
             "power (hp)": "110",
@@ -4061,7 +4020,7 @@ function data() {
         },
         {
             "name": "Volkswagen Super Beetle 117",
-            "economy (mpg)": "0",
+            "economy (mpg)": "",
             "cylinders": "4",
             "displacement (cc)": "97",
             "power (hp)": "48",

--- a/examples/parallelCoordinates.html
+++ b/examples/parallelCoordinates.html
@@ -35,7 +35,8 @@ nv.addGraph(function() {
 
     chart = nv.models.parallelCoordinates()
         .dimensionNames(["economy (mpg)", "cylinders", "displacement (cc)", "power (hp)", "weight (lb)", "0-60 mph (s)", "year"])
-        .lineTension(0.85);
+		.dimensionFormats(["0.5f", "e", "g", "d", "", "%", "p"])
+		.lineTension(0.85);
 		
 
     d3.select('#chart1 svg')

--- a/examples/parallelCoordinates.html
+++ b/examples/parallelCoordinates.html
@@ -12,8 +12,8 @@
         }
         svg {
             display: block;
-	    float: left;
-	    height: 450px !important;
+            float: left;
+            height: 450px !important;
             width: 850px !important;
         }
         html, body, #chart1, svg {

--- a/src/css/parallelcoordinates.css
+++ b/src/css/parallelcoordinates.css
@@ -22,3 +22,12 @@
     fill-opacity: 1;
 	stroke-width: 3px;
 }
+
+
+.nvd3 .missingValuesline line {
+  fill: none;
+  stroke: black;
+  stroke-width: 1;
+  stroke-opacity: 1;
+  stroke-dasharray: 5, 5; 
+}

--- a/src/models/parallelCoordinates.js
+++ b/src/models/parallelCoordinates.js
@@ -56,6 +56,8 @@ nv.models.parallelCoordinates = function() {
                     extent[0] = extent[0] - 1;
                     extent[1] = extent[1] + 1;
                 }
+                //Use 90% of (availableHeight - 12) for the axis range, 12 reprensenting the space necessary to display "undefined values" text.
+                //The remaining 10% are used to display the missingValue line.
                 y[d] = d3.scale.linear()
                     .domain(extent)
                     .range([(availableHeight - 12) * 0.9, 0]);
@@ -103,6 +105,7 @@ nv.models.parallelCoordinates = function() {
             missingValueslineText.enter().append('text');
             missingValueslineText.exit().remove();
             missingValueslineText.attr("y", availableHeight)
+                    //To have the text right align with the missingValues line, substract 92 representing the text size.
                     .attr("x", availableWidth - 92 - step / 2)
                     .text(function(d) { return d; });
 

--- a/src/models/parallelCoordinates.js
+++ b/src/models/parallelCoordinates.js
@@ -38,11 +38,24 @@ nv.models.parallelCoordinates = function() {
             // Setup Scales
             x.rangePoints([0, availableWidth], 1).domain(dimensionNames);
 
+            var onlyNanValues = {};
             // Extract the list of dimensions and create a scale for each.
             dimensionNames.forEach(function(d) {
+                var extent = d3.extent(data, function(p) { return +p[d]; });
+                onlyNanValues[d] = false;
+                if (extent[0] === undefined) {
+                    onlyNanValues[d] = true;
+                    extent[0] = 0;
+                    extent[1] = 0;
+                }
+                //Scale axis if there is only one value
+                if (extent[0] === extent[1]) {
+                    extent[0] = extent[0] - 1;
+                    extent[1] = extent[1] + 1;
+                }
                 y[d] = d3.scale.linear()
-                    .domain(d3.extent(data, function(p) { return +p[d]; }))
-                    .range([availableHeight, 0]);
+                    .domain(extent)
+                    .range([(availableHeight - 12) * 0.9, 0]);
 
                 y[d].brush = d3.svg.brush().y(y[d]).on('brush', brush);
 
@@ -57,6 +70,7 @@ nv.models.parallelCoordinates = function() {
 
             gEnter.append('g').attr('class', 'nv-parallelCoordinates background');
             gEnter.append('g').attr('class', 'nv-parallelCoordinates foreground');
+            gEnter.append('g').attr('class', 'nv-parallelCoordinates missingValuesline');
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
@@ -66,6 +80,28 @@ nv.models.parallelCoordinates = function() {
                         .on('dragstart', dragStart)
                         .on('drag', dragMove)
                         .on('dragend', dragEnd);
+
+            //Add missing value line
+            var missingValuesline, missingValueslineText;
+            var step = x.range()[1] - x.range()[0];
+            var axisWithMissingValues = [];
+            var lineData = [0 + step / 2, availableHeight - 12, availableWidth - step / 2, availableHeight - 12];
+            missingValuesline = wrap.select('.missingValuesline').selectAll('line').data([lineData]);
+            missingValuesline.enter().append('line');
+            missingValuesline.exit().remove();
+            missingValuesline.attr("x1", function(d) { return d[0]; })
+                    .attr("y1", function(d) { return d[1]; })
+                    .attr("x2", function(d) { return d[2]; })
+                    .attr("y2", function(d) { return d[3]; });
+
+
+            missingValueslineText = wrap.select('.missingValuesline').selectAll('text').data(["undefined values"]);
+            missingValueslineText.append('text').data(["undefined values"]);
+            missingValueslineText.enter().append('text');
+            missingValueslineText.exit().remove();
+            missingValueslineText.attr("y", availableHeight)
+                    .attr("x", availableWidth - 92 - step / 2)
+                    .text(function(d) { return d; });
 
             // Add grey background lines for context.
             var background = wrap.select('.background').selectAll('path').data(data);
@@ -78,7 +114,6 @@ nv.models.parallelCoordinates = function() {
             foreground.enter().append('path')
             foreground.exit().remove();
             foreground.attr('d', path).attr('stroke', color);
-
             foreground.on("mouseover", function (d, i) {
                 d3.select(this).classed('hover', true);
                 dispatch.elementMouseover({
@@ -142,7 +177,32 @@ nv.models.parallelCoordinates = function() {
 
             // Returns the path for a given data point.
             function path(d) {
-                return line(dimensionNames.map(function (p) { return [x(p), y[p](d[p])]; }));
+                return line(dimensionNames.map(function (p) {
+                    if(isNaN(d[p]) || isNaN(parseFloat(d[p]))) {
+                        var domain = y[p].domain();
+                        var range = y[p].range();
+                        var min = domain[0] - (domain[1] - domain[0]) / 9;
+
+                        if(axisWithMissingValues.indexOf(p) < 0) {
+
+                            var newscale = d3.scale.linear().domain([min, domain[1]]).range([availableHeight - 12, range[1]]);
+                            y[p].brush.y(newscale);
+                            axisWithMissingValues.push(p);
+                        }
+
+                        return [x(p), y[p](min)];
+                    }
+
+                    if(axisWithMissingValues.length > 0) {
+                        missingValuesline.style("display", "inline");
+                        missingValueslineText.style("display", "inline");
+                    } else {
+                        missingValuesline.style("display", "none");
+                        missingValueslineText.style("display", "none");
+                    }
+
+                     return [x(p), y[p](d[p])];
+                }));
             }
 
             // Handles a brush event, toggling the display of foreground lines.
@@ -161,6 +221,7 @@ nv.models.parallelCoordinates = function() {
                 active = []; //erase current active list
                 foreground.style('display', function(d) {
                     var isActive = actives.every(function(p, i) {
+                        if(isNaN(d[p]) && extents[i][0] == y[p].brush.y().domain()[0]) return true;
                         return extents[i][0] <= d[p] && d[p] <= extents[i][1];
                     });
                     if (isActive) active.push(d);

--- a/src/models/parallelCoordinates.js
+++ b/src/models/parallelCoordinates.js
@@ -13,6 +13,7 @@ nv.models.parallelCoordinates = function() {
         , x = d3.scale.ordinal()
         , y = {}
         , dimensionNames = []
+        , dimensionFormats = []
         , color = nv.utils.defaultColor()
         , filters = []
         , active = []
@@ -165,8 +166,8 @@ nv.models.parallelCoordinates = function() {
                 .call(axisDrag);
 
             dimensions.select('.nv-axis')
-                .each(function (d) {
-                    d3.select(this).call(axis.scale(y[d]));
+                .each(function (d, i) {
+                    d3.select(this).call(axis.scale(y[d]).tickFormat(d3.format(dimensionFormats[i])));
                 });
 
                 dimensions.select('.nv-parallelCoordinates-brush')
@@ -286,6 +287,7 @@ nv.models.parallelCoordinates = function() {
         width:         {get: function(){return width;},           set: function(_){width= _;}},
         height:        {get: function(){return height;},          set: function(_){height= _;}},
         dimensionNames: {get: function() { return dimensionNames;}, set: function(_){dimensionNames= _;}},
+        dimensionFormats : {get: function(){return dimensionFormats;}, set: function (_){dimensionFormats=_;}},
         lineTension:   {get: function(){return lineTension;},     set: function(_){lineTension = _;}},
 
         // deprecated options


### PR DESCRIPTION
- Support missing values : Missing values cannot be displayed per definition, since they are missing. Nevertheless, they also provide useful information when trying to understand the data. The option proposed is to exploit the available horizontal space to introduce a third dimension outside of the normal range. Whenever a displayed row has a missing value in one dimension, the connecting line falls out of the regular space and falls onto the missing value axis.

Ref:  http://informationandvisualization.de/blog/parallel-coordinates-and-missing-values

![clipboard01](https://cloud.githubusercontent.com/assets/6142727/6714274/b7966e02-cd97-11e4-94d2-cff89eee78b1.jpg)

- Support only one line displayed (Fix)
- Possibility to define a tickFormat for each axis