### PR TITLE
Fix tooltip position to be correct if you use chartContainer

### DIFF
--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -138,7 +138,10 @@
                     // now print the all out in alphabetical order
                     var alpha = Object.keys(alloptions).sort();
                     for (var j4 in alpha) {
-                        parse_options(ul, alloptions[alpha[j4]]);
+                        // ignore internal options (start with an underscore)
+                        if (alpha[j4].substring(0, 1) !== '_') {
+                            parse_options(ul, alloptions[alpha[j4]]);
+                        }
                     }
 
                     // append the list of options to the dom

--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -10,7 +10,7 @@ nv.interactiveGuideline = function() {
     "use strict";
 
     var tooltip = nv.models.tooltip();
-    tooltip.duration(0).hideDelay(0).hidden(false);
+    tooltip.duration(0).hideDelay(0)._isInteractiveLayer(true).hidden(false);
 
     //Public settings
     var width = null;

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -46,6 +46,11 @@
             ,   headerEnabled = true
         ;
 
+        // set to true by interactive layer to adjust tooltip positions
+        // eventually we should probably fix interactive layer to get the position better.
+        // for now this is needed if you want to set chartContainer for normal tooltips, else it "fixes" it to broken
+        var isInteractiveLayer = false;
+
         //Generates a unique id when you create a new tooltip() object
         var id = "nvtooltip-" + Math.floor(Math.random() * 100000);
 
@@ -325,7 +330,7 @@
                     tooltipElem.innerHTML = newContent;
                 }
 
-                if (chartContainer) {
+                if (chartContainer && isInteractiveLayer) {
                     nv.dom.read(function() {
                         var svgComp = chartContainer.getElementsByTagName("svg")[0];
                         var svgOffset = {left:0,top:0};
@@ -381,6 +386,9 @@
             valueFormatter: {get: function(){return valueFormatter;}, set: function(_){valueFormatter=_;}},
             headerFormatter: {get: function(){return headerFormatter;}, set: function(_){headerFormatter=_;}},
             headerEnabled:   {get: function(){return headerEnabled;}, set: function(_){headerEnabled=_;}},
+
+            // internal use only, set by interactive layer to adjust position.
+            _isInteractiveLayer: {get: function(){return isInteractiveLayer;}, set: function(_){isInteractiveLayer=!!_;}},
 
             // options with extra logic
             position: {get: function(){return position;}, set: function(_){


### PR DESCRIPTION
If you use chartContainer on normal tooltips, don't do special calculations intended for the interactive layer tooltip.  This fixes the tooltip position issue from https://github.com/novus/nvd3/issues/893

The added option should never be used by anything other than interactive guideline so I prefixed it with an underscore and set the documentation to ignore options starting with an underscore. 