### PR TITLE
Remove bower install from postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "nvd3",
   "version": "1.7.1",
   "scripts": {
-    "postinstall": "bower install",
     "test": "grunt"
   },
   "devDependencies": {


### PR DESCRIPTION
Having `bower install` inside the postinstall hook prevents this package from being installed via npm when bower isn't available