### PR TITLE
nv.graphs is never emptied -- mem leak w/refreshed data on page

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -8,7 +8,6 @@ nv.tooltip = nv.tooltip || {}; // For the tooltip system
 nv.utils = nv.utils || {}; // Utility subsystem
 nv.models = nv.models || {}; //stores all the possible models/components
 nv.charts = {}; //stores all the ready to use charts
-//nv.graphs = []; //stores all the graphs currently on the page -- NYI fully 
 nv.logs = {}; //stores some statistics and potential error messages
 nv.dom = {}; //DOM manipulation functions
 
@@ -92,7 +91,6 @@ nv.render = function render(step) {
         for (var i = 0; i < step && (graph = nv.render.queue[i]); i++) {
             chart = graph.generate();
             if (typeof graph.callback == typeof(Function)) graph.callback(chart);
-            //nv.graphs.push(chart);
         }
 
         nv.render.queue.splice(0, i);

--- a/src/core.js
+++ b/src/core.js
@@ -8,7 +8,7 @@ nv.tooltip = nv.tooltip || {}; // For the tooltip system
 nv.utils = nv.utils || {}; // Utility subsystem
 nv.models = nv.models || {}; //stores all the possible models/components
 nv.charts = {}; //stores all the ready to use charts
-nv.graphs = []; //stores all the graphs currently on the page
+//nv.graphs = []; //stores all the graphs currently on the page -- NYI fully 
 nv.logs = {}; //stores some statistics and potential error messages
 nv.dom = {}; //DOM manipulation functions
 
@@ -92,7 +92,7 @@ nv.render = function render(step) {
         for (var i = 0; i < step && (graph = nv.render.queue[i]); i++) {
             chart = graph.generate();
             if (typeof graph.callback == typeof(Function)) graph.callback(chart);
-            nv.graphs.push(chart);
+            //nv.graphs.push(chart);
         }
 
         nv.render.queue.splice(0, i);


### PR DESCRIPTION
I encountered the memory leak when ajax refreshing in data for a continuously updating dashboard. It was only glaring for me because I had eight graphs of time series data on a single page and got to the dead browser screen pretty quick. Commenting out seems the right immediate fix as the array isn't used. Longer term if nv.graphs is desired, you'd have to make sure it stayed a fixed size -- splicing off as you go.