### PR TITLE
Remove bower install from postinstall hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ before_install:
     - "npm install -g grunt-cli"
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
-install: npm install
+install:
+    - "npm install"
+    - "bower install"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "nvd3",
   "version": "1.7.1",
   "scripts": {
-    "postinstall": "bower install",
     "test": "grunt"
   },
   "devDependencies": {


### PR DESCRIPTION
Followup of #919.
Having `bower install` in the postinstall hook makes this library not possible to install through npm in environments where bower is not available.
To keep compatibility with travis, `bower install` is now invoked after npm install in the travis.yml