### PR TITLE
Fix #862, legend position 'right' buggy

### DIFF
--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -123,15 +123,13 @@ nv.models.pieChart = function() {
                     wrap.select('.nv-legendWrap')
                         .attr('transform', 'translate(0,' + (-margin.top) +')');
                 } else if (legendPosition === "right") {
-                    legend.height( availableHeight ).key(pie.x());
-
-                    if ( margin.right != legend.width()) {
-                        if (legend.width() > availableWidth / 2) {
-                            legend.width(availableWidth / 2);
-                            availableWidth -= legend.width();
-                        }
-                        margin.right = legend.width();
+                    var legendWidth = nv.models.legend().width();
+                    if (availableWidth / 2 < legendWidth) {
+                        legendWidth = (availableWidth / 2)
                     }
+                    legend.height(availableHeight).key(pie.x());
+                    legend.width(legendWidth);
+                    availableWidth -= legend.width();
 
                     wrap.select('.nv-legendWrap')
                         .datum(data)


### PR DESCRIPTION
This seems to fix the bugginess in issue #862; it adjusts as the browser window in sized up and down and doesn't translate the legend way off to the right on first load.

I couldn't get a good example working in jsfiddle because of all the resizing, but i created [this gist](https://gist.github.com/rreinhardt9/6b055863fcf41c76a5ce) that can be used to try it out locally.

I wanted to open this PR for discussion, like I mentioned in the issue I'm pretty new to nv and d3.

Thanks!