### PR TITLE
Fix typo (presumably) in nvtooltip h3 border-radius.

### DIFF
--- a/src/nv.d3.css
+++ b/src/nv.d3.css
@@ -98,7 +98,7 @@ svg.nvd3-svg {
 
   -webkit-border-radius: 5px 5px 0 0;
   -moz-border-radius: 5px 5px 0 0;
-  border-radius: 1px 5px 0 0;
+  border-radius: 5px 5px 0 0;
 }
 
 .nvtooltip p {


### PR DESCRIPTION
For some reason, the value of the border-top-left-radius property was different than
the value of the webkit and mozilla versions of the property.