### PR TITLE
Fix the border-top-left-radius property of .nvtooltip h3.

### DIFF
--- a/src/css/tooltip.css
+++ b/src/css/tooltip.css
@@ -61,7 +61,7 @@
 
     -webkit-border-radius: 5px 5px 0 0;
     -moz-border-radius: 5px 5px 0 0;
-    border-radius: 1px 5px 0 0;
+    border-radius: 5px 5px 0 0;
 }
 
 .nvtooltip p {


### PR DESCRIPTION
For some reason, the value of the border-top-left-radius property was
different than the value of the webkit and mozilla versions of the
property (1px vs 5px).

This is just like the earlier #956, but now against the development 
branch (sorry for the noise!).

