### PR TITLE
fix historicalBarChart tooltip not hidding when moused out, #952

### DIFF
--- a/src/models/historicalBarChart.js
+++ b/src/models/historicalBarChart.js
@@ -29,7 +29,7 @@ nv.models.historicalBarChart = function(bar_model) {
         , state = {}
         , defaultState = null
         , noData = null
-        , dispatch = d3.dispatch('stateChange', 'changeState', 'renderEnd')
+        , dispatch = d3.dispatch('tooltipHide', 'stateChange', 'changeState', 'renderEnd')
         , transitionDuration = 250
         ;
 


### PR DESCRIPTION
Just needed to add 'tooltipHide' to list of dispatch functions in the historicalBarChart.js file. #952 