### PR TITLE
Fix interactiveGuideline bugs when data is missing.

### DIFF
--- a/examples/lineChartWithInteractiveAndMissingData.html
+++ b/examples/lineChartWithInteractiveAndMissingData.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <link href="../build/nv.d3.css" rel="stylesheet" type="text/css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.2/d3.min.js" charset="utf-8"></script>
+    <script src="../build/nv.d3.js"></script>
+
+    <style>
+        text {
+            font: 12px sans-serif;
+        }
+        svg {
+            display: block;
+        }
+        html, body, #chart1, svg {
+            margin: 0px;
+            padding: 0px;
+            height: 100%;
+            width: 100%;
+        }
+
+        .dashed {
+            stroke-dasharray: 5,5;
+        }
+    </style>
+</head>
+<body class='with-3d-shadow with-transitions'>
+
+<div id="chart1"></div>
+
+<script>
+    // Wrapping in nv.addGraph allows for '0 timeout render', stores rendered charts in nv.graphs, and may do more in the future... it's NOT required
+    var chart;
+    var data;
+
+
+    nv.addGraph(function() {
+        chart = nv.models.lineChart()
+            .options({
+                transitionDuration: 300,
+                useInteractiveGuideline: true
+            })
+        ;
+
+        // chart sub-models (ie. xAxis, yAxis, etc) when accessed directly, return themselves, not the parent chart, so need to chain separately
+        chart.xAxis
+            .axisLabel("Time (s)")
+            .tickFormat(d3.format(',.1f'))
+            .staggerLabels(true)
+        ;
+
+        chart.yAxis
+            .axisLabel('Voltage (v)')
+            .tickFormat(d3.format(',.2f'))
+        ;
+
+        data = sinAndCos();
+
+        d3.select('#chart1').append('svg')
+            .datum(data)
+            .call(chart);
+
+        nv.utils.windowResize(chart.update);
+
+        return chart;
+    });
+
+    function sinAndCos() {
+        var sin = [],
+            sin2 = [],
+            cos = [],
+            rand = [],
+            rand2 = []
+            ;
+
+
+        for (var i = 0; i < 100; i++) {
+
+            sin.push(i % 17 === 0 ? {x: null, y: null} : {x: i, y: Math.sin(i/10) });
+            sin2.push(i % 19 === 0 ? {x: null, y: null} : {x: i, y: Math.sin(i/5) * 0.4 - 0.25});
+            cos.push(i % 7 === 0 ? {x: null, y:null} : {x: i, y:.5 * Math.cos(i/10)});
+            rand.push(i % 11 === 0 ? {x: null, y: null} : {x: i , y: Math.random() / 10});
+            rand2.push( i % 13 === 0 ? {x: null, y: null} : {x: i, y: Math.cos(i/10) + Math.random() / 10 });
+        }
+
+        return [
+            {
+                area: true,
+                values: sin,
+                key: "Sine Wave",
+                color: "#ff7f0e",
+                strokeWidth: 4,
+                classed: 'dashed'
+            },
+            {
+                values: cos,
+                key: "Cosine Wave",
+                color: "#2ca02c"
+            },
+            {
+                values: rand,
+                key: "Random Points",
+                color: "#2222ff"
+            },
+            {
+                values: rand2,
+                key: "Random Cosine",
+                color: "#667711",
+                strokeWidth: 3.5
+            },
+            {
+                area: true,
+                values: sin2,
+                key: "Fill opacity",
+                color: "#EF9CFB",
+                fillOpacity: .1
+            }
+        ];
+    }
+
+</script>
+</body>
+</html>

--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -295,3 +295,60 @@ nv.nearestValueIndex = function (values, searchVal, threshold) {
     });
     return indexToHighlight;
 };
+
+/*
+For all series in data:
+ - add filteredValues attribute, which is an array of values where both x and y are not undefined nor null
+ - add filteredIndexToOrigIndex for converting the index of a value in filteredValues to the index of the same value
+   in the original values array.
+ These attributes are can be used by charts that use interactiveBisect on series with missing data.
+ See example lineChartWithInteractiveAndMissingData.html
+*/
+nv.filterValuesForBisect = function(data, xAccessor, yAccessor) {
+    "use strict";
+
+    if (data == null) {
+        return;
+    }
+
+    if (!(data instanceof Array)) {
+        // Convert to array
+        data = [data];
+    }
+
+    var _xAccessor;
+    if (typeof xAccessor !== 'function') {
+        _xAccessor = function(d) {
+            return d.x;
+        }
+    } else {
+        _xAccessor = xAccessor;
+    }
+
+    var _yAccessor;
+    if (typeof yAccessor !== 'function') {
+        _yAccessor = function(d) {
+            return d.y;
+        }
+    } else {
+        _yAccessor = yAccessor;
+    }
+    
+
+    var i, j, v, series;
+    for(i = 0; i < data.length; i++) {
+        series = data[i];
+        var filteredValues = [];
+        var filteredIndexToOrigIndex = [];
+        for(j = 0; j < (series.values && series.values.length || 0); j++) {
+            v = series.values[j];
+            if (_xAccessor(v) != null && _yAccessor(v) != null) {
+                filteredValues.push(v);
+                filteredIndexToOrigIndex.push(j);
+            }
+        }
+        series.filteredValues = filteredValues;
+        series.filteredIndexToOrigIndex = filteredIndexToOrigIndex;
+    }
+
+};


### PR DESCRIPTION
This commit fixes a bug with the interactive guideline
when data is missing (x, y, or both set to null or undefined),
Missing data caused incorrect points to be highlighted, likely
due to undefined behavior with d3.bisect when nulls or undefined's
are encountered.

This fix creates a filtered array of values for each series by
removing points that are undefined in x or y, and a map from the index
of a point in the filtered array to the index of the original point.
These structures are used to correctly highlight points and populate
tooltip when data is missing.