### PR TITLE
Added option to SunburstChart to scale to size, not only count

### DIFF
--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -55,7 +55,8 @@
                 'discreteBarChart',
                 'cumulativeLineChart',
                 'bulletChart',
-                'ohlcBarChart'
+                'ohlcBarChart',
+                'sunburstChart'
             ].sort();
             var parts = [
                 'line',
@@ -70,7 +71,8 @@
                 'legend',
                 'tooltip',
                 'sparkline',
-                'discreteBar'
+                'discreteBar',
+                'sunburst'
             ].sort();
             var c = $('#optionlist');
             var jump = $('#optionjump');
@@ -281,9 +283,9 @@
         <div id="optionjump"></div>
 
         <div style="height: 50px"></div>
-		
+
 		<h3 class="option"><span class="expand all">[ <a href="javascript:$('#optionlist>ul').toggle()">toggle all</a> ]</span></h3>
-		
+
         <div id="optionlist"></div>
 
     </section>
@@ -846,6 +848,12 @@ as well as used to print out examples using those example inputs.
         },
         tooltipElem: {
             desc: "For tooltip: returns the dom element of the tooltip.  This is read-only, you cannot set this value."
+        },
+        mode: {
+            desc: "For sunburst only: specifies the mode of drawing the sunburst segments. Can be 'size' or 'count'. 'size' draws the segments according to the 'size' attribute of the leaf nodes, 'count' draws according to the amount of siblings a node has.",
+            default: "count",
+            refs: ["http://bl.ocks.org/kerryrodden/477c1bfb081b783f80ad"],
+            examples: ["size"]
         }
     };
 </script>

--- a/src/models/sunburst.js
+++ b/src/models/sunburst.js
@@ -9,6 +9,8 @@ nv.models.sunburst = function() {
     var margin = {top: 0, right: 0, bottom: 0, left: 0}
         , width = null
         , height = null
+        , mode = "count"
+        , modes = {count: function(d) { return 1; }, size: function(d) { return d.size }}
         , id = Math.floor(Math.random() * 10000) //Create semi-unique ID in case user doesn't select one
         , color = nv.utils.defaultColor()
         , duration = 500
@@ -68,8 +70,8 @@ nv.models.sunburst = function() {
             y.range([0, radius]);
 
             node = node || data;
-            path =
-                g.data(partition.nodes).enter()
+            partition.value(modes[mode] || modes["count"]);
+            path = g.data(partition.nodes).enter()
                 .append("path")
                 .attr("d", arc)
                 .style("fill", function (d) {
@@ -170,6 +172,7 @@ nv.models.sunburst = function() {
         // simple options, just get/set the necessary values
         width:      {get: function(){return width;}, set: function(_){width=_;}},
         height:     {get: function(){return height;}, set: function(_){height=_;}},
+        mode:       {get: function(){return mode;}, set: function(_){mode=_;}},
         id:         {get: function(){return id;}, set: function(_){id=_;}},
         duration:   {get: function(){return duration;}, set: function(_){duration=_;}},
 


### PR DESCRIPTION
Right now, the size of the 'pieces' of the sunburst chart is not respective to their data, but to the number of children of a given parent.
This commit adds an option "mode", that allows the user to choose the two modes as illustrated 
[here](http://bl.ocks.org/kerryrodden/477c1bfb081b783f80ad).

As an added bonus, one can now display the sum of the children's values in the tooltip of a given parent node as follows:

```
chart.sunburst.dispatch.on('elementMouseover.tooltip', function(evt) {
    evt['series'] = {
        key: evt.data.name,
        value: evt.data.value,
        color: evt.color
    };
    chart.tooltip.data(evt).hidden(false);
});

```