### PR TITLE
SunburstChart: Expose 'tooltip' public variable

### DIFF
--- a/src/models/sunburstChart.js
+++ b/src/models/sunburstChart.js
@@ -108,6 +108,7 @@ nv.models.sunburstChart = function() {
     // expose chart's sub-components
     chart.dispatch = dispatch;
     chart.sunburst = sunburst;
+    chart.tooltip = tooltip;
     chart.options = nv.utils.optionsFunc.bind(chart);
 
     // use Object get/set functionality to map between vars and chart functions


### PR DESCRIPTION
This PR exposes the 'tooltip' public variable of the SunburstChart, in order to be consistent with the other charts which expose the 'tooltip' as well.