### PR TITLE
StackedAreaChart: Fix wrong yAxis tickFormat on chart.update() in Expanded view

### DIFF
--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -263,12 +263,16 @@ nv.models.stackedAreaChart = function() {
                     .tickSize(-availableWidth, 0);
 
                     if (stacked.style() === 'expand' || stacked.style() === 'stack_percent') {
-                        oldYTickFormat = yAxis.tickFormat();
+                        if ( !oldYTickFormat )
+                            oldYTickFormat = yAxis.tickFormat();
                         //Forces the yAxis to use percentage in 'expand' mode.
                         yAxis.tickFormat(d3.format('%'));
                     }
                     else {
-                        if (oldYTickFormat) yAxis.tickFormat(oldYTickFormat);
+                        if (oldYTickFormat) {
+                            yAxis.tickFormat(oldYTickFormat);
+                            oldYTickFormat = null;
+                        }
                     }
 
                 g.select('.nv-y.nv-axis')


### PR DESCRIPTION
Bug: when calling chart.update() in expanded view and then switching to another view the yTickFormat remains the percentage format.

Fix: only set oldYTickFormat when changing from another view to expanded (and not when remaining in expanded view).