### PR TITLE
fix multichart tooltip position on pages with scroll

### DIFF
--- a/build/nv.d3.js
+++ b/build/nv.d3.js
@@ -1,4 +1,4 @@
-/* nvd3 version 1.7.1(https://github.com/novus/nvd3) 2015-02-08 */
+/* nvd3 version 1.7.1(https://github.com/novus/nvd3) 2015-04-22 */
 (function(){
 
 // set up main nv object on window
@@ -7843,7 +7843,7 @@ nv.models.multiChart = function() {
             y = ((e.series.yAxis == 2) ? yAxis2 : yAxis1).tickFormat()(lines1.y()(e.point, e.pointIndex)),
             content = tooltip(e.series.key, x, y, e, chart);
 
-        nv.tooltip.show([left, top], content, undefined, undefined, offsetElement.offsetParent);
+        nv.tooltip.show([left, top], content, undefined, undefined, offsetElement);
     };
 
     function chart(selection) {
@@ -8224,7 +8224,6 @@ nv.models.multiChart = function() {
 
     return chart;
 };
-
 
 nv.models.ohlcBar = function() {
     "use strict";

--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -56,7 +56,7 @@ nv.models.multiChart = function() {
             y = ((e.series.yAxis == 2) ? yAxis2 : yAxis1).tickFormat()(lines1.y()(e.point, e.pointIndex)),
             content = tooltip(e.series.key, x, y, e, chart);
 
-        nv.tooltip.show([left, top], content, undefined, undefined, offsetElement.offsetParent);
+        nv.tooltip.show([left, top], content, undefined, undefined, offsetElement);
     };
 
     function chart(selection) {
@@ -437,4 +437,3 @@ nv.models.multiChart = function() {
 
     return chart;
 };
-


### PR DESCRIPTION
the position of the tooltip was wrong depending of the scroll of the page. Tooltip should always appear near to the point.