### PR TITLE
SunburstChart: Fix setting duration

### DIFF
--- a/src/models/sunburstChart.js
+++ b/src/models/sunburstChart.js
@@ -125,6 +125,7 @@ nv.models.sunburstChart = function() {
         duration: {get: function(){return duration;}, set: function(_){
             duration = _;
             renderWatch.reset(duration);
+            sunburst.duration(duration);
         }},
         margin: {get: function(){return margin;}, set: function(_){
             margin.top    = _.top    !== undefined ? _.top    : margin.top;


### PR DESCRIPTION
When setting duration on a SunburstChart object, it should also set the duration of the underlying sunburst object.