### PR TITLE
fixing stackedArea tooltip formatting

### DIFF
--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -12,7 +12,6 @@ nv.models.stackedAreaChart = function() {
         , legend = nv.models.legend()
         , controls = nv.models.legend()
         , interactiveLayer = nv.interactiveGuideline()
-        , tooltip = nv.models.tooltip()
         ;
 
     var margin = {top: 30, right: 25, bottom: 50, left: 60}
@@ -41,7 +40,7 @@ nv.models.stackedAreaChart = function() {
     xAxis.orient('bottom').tickPadding(7);
     yAxis.orient((rightAlignYAxis) ? 'right' : 'left');
 
-    tooltip
+    interactiveLayer.tooltip
         .headerFormatter(function(d, i) {
             return xAxis.tickFormat()(d, i);
         })
@@ -375,15 +374,12 @@ nv.models.stackedAreaChart = function() {
                 //If we are in 'expand' mode, force the format to be a percentage.
                 var valueFormatter = (stacked.style() == 'expand') ?
                     function(d,i) {return d3.format(".1%")(d);} :
-                    tooltip.valueFormatter(); 
-                
-                var headerFormatter = tooltip.headerFormatter();
+                    interactiveLayer.tooltip.valueFormatter(); 
 
                 interactiveLayer.tooltip
                     .position({left: pointXLocation + margin.left, top: e.mouseY + margin.top})
                     .chartContainer(that.parentNode)
                     .valueFormatter(valueFormatter)
-                    .headerFormatter(headerFormatter)
                     .data(
                     {
                         value: xValue,
@@ -450,7 +446,6 @@ nv.models.stackedAreaChart = function() {
     chart.xAxis = xAxis;
     chart.yAxis = yAxis;
     chart.interactiveLayer = interactiveLayer;
-    chart.tooltip = tooltip;
 
     chart.dispatch = dispatch;
     chart.options = nv.utils.optionsFunc.bind(chart);

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -375,11 +375,15 @@ nv.models.stackedAreaChart = function() {
                 //If we are in 'expand' mode, force the format to be a percentage.
                 var valueFormatter = (stacked.style() == 'expand') ?
                     function(d,i) {return d3.format(".1%")(d);} :
-                    function(d,i) {return yAxis.tickFormat()(d); };
+                    tooltip.valueFormatter(); 
+                
+                var headerFormatter = tooltip.headerFormatter();
+
                 interactiveLayer.tooltip
                     .position({left: pointXLocation + margin.left, top: e.mouseY + margin.top})
                     .chartContainer(that.parentNode)
                     .valueFormatter(valueFormatter)
+                    .headerFormatter(headerFormatter)
                     .data(
                     {
                         value: xValue,


### PR DESCRIPTION
Allowing user to specify how to format tooltip header and values like in
other charts (was previously not possible to format values)

Examples summarizing changes: http://nvd3-lucaslin.parseapp.com/stackedarea-tooltip-formatting/

Currently, using `chart.tooltip.valueFormatter()` and  `chart.tooltip.headerFormatter()` works to format tooltips in [other chart models](http://nvd3-lucaslin.parseapp.com/stackedarea-tooltip-formatting/before-change/multibar-tooltip.html) but not those in [stackedAreaChart](http://nvd3-lucaslin.parseapp.com/stackedarea-tooltip-formatting/before-change/just-tooltip.html).
![image](https://cloud.githubusercontent.com/assets/1623899/7304667/b76959c6-e9ad-11e4-8021-c3d6df1d72a2.png)


There is a [work-around hack](http://nvd3-lucaslin.parseapp.com/stackedarea-tooltip-formatting/before-change/interactivelayer-tooltip.html) that works for header formatting but not value formatting by using `chart.interactiveLayer.tooltip` instead of `chart.tooltip`. 
![image](https://cloud.githubusercontent.com/assets/1623899/7304538/ee467434-e9ac-11e4-884d-694497932aec.png)
The `valueFormatter()` doesn't work because it is explicitly overwritten (in line 378) by `yAxis.tickFormat()`.
![image](https://cloud.githubusercontent.com/assets/1623899/7304690/e562db18-e9ad-11e4-8760-32ad5870b30c.png)

Regardless, users should be able to use `chart.tooltip` like in other charts.

The bug comes about because the user-provided tooltip formatting functions are never passed to `interactiveLayer.tooltip`.

By providing  `tooltip.valueFormatter()` and `tooltip.headerFormatter()` to interactiveLayer, the user's function will be used if provided, and the correct default (like `yAxis.tickFormat()` for `valueFormatter()`) will still be used  if not (see line 44).

## Result:
 `tooltip.valueFormatter()` and `tooltip.headerFormatter()` format the values and headers respectively.
[Example of proposed fix](http://nvd3-lucaslin.parseapp.com/stackedarea-tooltip-formatting/after-change/just-tooltip.html)
![image](https://cloud.githubusercontent.com/assets/1623899/7304813/78a40e1a-e9ae-11e4-8702-93d8695eff17.png)
