### PR TITLE
Allow multiple markers and labels on bullet chart

### DIFF
--- a/examples/bulletChart.html
+++ b/examples/bulletChart.html
@@ -54,10 +54,10 @@ Bullet Chart with Custom Labels
         "subtitle":"US$, in thousands",
         "ranges":[150,225,300],
         "measures":[220],
-        "markers":[250],
+        "markers":[250, 100],
+        "markerLabels":['Target Inventory', 'Low Inventory'],
         "rangeLabels":['Maximum Inventory','Average Inventory','Minimum Inventory'],
-        "measureLabels":['Current Inventory'],
-        "markerLabels":['Target Inventory']
+        "measureLabels":['Current Inventory']
     }];
 
     //TODO: to be consistent with other models, should be appending a g to an already made svg, not creating the svg element

--- a/src/models/bullet.js
+++ b/src/models/bullet.js
@@ -69,7 +69,6 @@ nv.models.bullet = function() {
             gEnter.append('rect').attr('class', 'nv-range nv-rangeAvg');
             gEnter.append('rect').attr('class', 'nv-range nv-rangeMin');
             gEnter.append('rect').attr('class', 'nv-measure');
-            gEnter.append('path').attr('class', 'nv-markerTriangle');
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
@@ -129,34 +128,41 @@ nv.models.bullet = function() {
                 });
 
             var h3 =  availableHeight / 6;
-            if (markerz[0]) {
-                g.selectAll('path.nv-markerTriangle')
-                    .attr('transform', function(d) { return 'translate(' + x1(markerz[0]) + ',' + (availableHeight / 2) + ')' })
-                    .attr('d', 'M0,' + h3 + 'L' + h3 + ',' + (-h3) + ' ' + (-h3) + ',' + (-h3) + 'Z')
-                    .on('mouseover', function() {
-                        dispatch.elementMouseover({
-                            value: markerz[0],
-                            label: markerLabelz[0] || 'Previous',
-                            color: d3.select(this).style("fill")
-                        })
-                    })
-                    .on('mousemove', function() {
-                        dispatch.elementMousemove({
-                            value: measurez[0],
-                            label: measureLabelz[0] || 'Previous',
-                            color: d3.select(this).style("fill")
-                        })
-                    })
-                    .on('mouseout', function() {
-                        dispatch.elementMouseout({
-                            value: markerz[0],
-                            label: markerLabelz[0] || 'Previous',
-                            color: d3.select(this).style("fill")
-                        })
-                    });
-            } else {
-                g.selectAll('path.nv-markerTriangle').remove();
-            }
+
+            var markerData = markerz.map( function(marker, index) {
+                return {value: marker, label: markerLabelz[index]}
+            });
+            gEnter
+              .selectAll("path.nv-markerTriangle")
+              .data(markerData)
+              .enter()
+              .append('path')
+              .attr('class', 'nv-markerTriangle')
+              .attr('transform', function(d) { return 'translate(' + x1(d.value) + ',' + (availableHeight / 2) + ')' })
+              .attr('d', 'M0,' + h3 + 'L' + h3 + ',' + (-h3) + ' ' + (-h3) + ',' + (-h3) + 'Z')
+              .on('mouseover', function(d) {
+                dispatch.elementMouseover({
+                  value: d.value,
+                  label: d.label || 'Previous',
+                  color: d3.select(this).style("fill"),
+                  pos: [x1(d.value), availableHeight/2]
+                })
+
+              })
+              .on('mousemove', function(d) {
+                  dispatch.elementMousemove({
+                      value: d.value,
+                      label: d.label || 'Previous',
+                      color: d3.select(this).style("fill")
+                  })
+              })
+              .on('mouseout', function(d, i) {
+                  dispatch.elementMouseout({
+                      value: d.value,
+                      label: d.label || 'Previous',
+                      color: d3.select(this).style("fill")
+                  })
+              });
 
             wrap.selectAll('.nv-range')
                 .on('mouseover', function(d,i) {

--- a/test/mocha/bullet.coffee
+++ b/test/mocha/bullet.coffee
@@ -18,7 +18,7 @@ describe 'NVD3', ->
             subtitle: 'US$ in thousands'
             ranges: [10,20,30]
             measures: [40]
-            markers: [50]
+            markers: [50, 100]
 
         options =
             orient: 'left'
@@ -54,6 +54,10 @@ describe 'NVD3', ->
         it 'renders', ->
             wrap = builder1.$ 'g.nvd3.nv-bulletChart'
             should.exist wrap[0]
+
+        it 'displays multiple markers', ->
+          markers = document.querySelectorAll '.nv-markerTriangle'
+          markers.length.should.equal 2
 
         it 'has correct g.nvd3.nv-bulletChart position', ->
           chart = builder1.$ 'g.nvd3.nv-bulletChart'


### PR DESCRIPTION
Currently, the API shows that we can provide an array of markers and labels to the bulletChart but unfortunately, it only displays the first marker.

This adds the ability to pass an array of markers and an array of labels and have them all show up.

I'm happy to make any changes that are recommended, this was just my first pass when I needed this feature.

I'm also happy to squash all the commit messages, I just assume there will be some feedback first so I thought I'd wait!

Thanks!