### PR TITLE
Fix percent bug in pie chart

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -314,7 +314,7 @@ nv.models.pie = function() {
                                     label = valueFormat(getY(d.data));
                                     break;
                                 case 'percent':
-                                    label = valueFormat(percent);
+                                    label = d3.format('%')(percent);
                                     break;
                             }
                         }


### PR DESCRIPTION
Hey guys I noticed a bug in the pie chart when you specify the labelType as percent.
Here is a before and after of the problem:
![screen shot 2015-04-24 at 4 09 08 pm](https://cloud.githubusercontent.com/assets/4017654/7329455/c8272726-ea9c-11e4-9b5e-b31c175f40bd.png)
![screen shot 2015-04-24 at 4 10 11 pm](https://cloud.githubusercontent.com/assets/4017654/7329457/ca244720-ea9c-11e4-8d56-c7798821e693.png)
