### PR TITLE
fixed pie/donut chart wrong label positions bug

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -213,10 +213,8 @@ nv.models.pie = function() {
                             if (startAngle !== false) labelsArc[i].startAngle(startAngle);
                             if (endAngle !== false) labelsArc[i].endAngle(endAngle);
                         }
-                    } else {
-                        if (!donut) {
+                    } else if (!donut) {
                             labelsArc[i].innerRadius(0);
-                        }
                     }
                 }
 

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -205,15 +205,17 @@ nv.models.pie = function() {
                 // This does the normal label
                 var labelsArc = [];
                 for (var i = 0; i < data[0].length; i++) {
-                    labelsArc.push(d3.svg.arc().innerRadius(0));
+                    labelsArc.push(arcs[i]);
 
                     if (labelsOutside) {
                         if (donut) {
                             labelsArc[i] = d3.svg.arc().outerRadius(arcs[i].outerRadius());
                             if (startAngle !== false) labelsArc[i].startAngle(startAngle);
                             if (endAngle !== false) labelsArc[i].endAngle(endAngle);
-                        } else {
-                            labelsArc[i] = arcs[i];
+                        }
+                    } else {
+                        if (!donut) {
+                            labelsArc[i].innerRadius(0);
                         }
                     }
                 }


### PR DESCRIPTION
Fixed bug #861 
Had to change the logic to not create an entire new arc object and instead use the one already created before settings its innerRadius to zero.
Here is a before and after:
![croppercapture 4](https://cloud.githubusercontent.com/assets/4017654/7334285/76341842-eb4c-11e4-83c0-587a93b03f28.jpg)
![croppercapture 5](https://cloud.githubusercontent.com/assets/4017654/7334286/78b06c06-eb4c-11e4-8164-9e2056093029.jpg)
