### PR TITLE
fixing stackedArea tooltip formatting

### DIFF
--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -389,25 +389,22 @@ nv.models.stackedAreaChart = function() {
 
                 var xValue = xAxis.tickFormat()(chart.x()(singlePoint,pointIndex));
 
+                var valueFormatter = interactiveLayer.tooltip.valueFormatter();
                 // Keeps track of the tooltip valueFormatter if the chart changes to expanded view
                 if (stacked.style() === 'expand' || stacked.style() === 'stack_percent') {
                     if ( !oldValueFormatter ) {
-                        oldValueFormatter = interactiveLayer.tooltip.valueFormatter();
+                        oldValueFormatter = valueFormatter;
                     }
                     //Forces the tooltip to use percentage in 'expand' mode.
-                    interactiveLayer.tooltip.valueFormatter(yAxis.tickFormat(d3.format('%')));
+                    valueFormatter = d3.format(".1%");
                 }
                 else {
                     if (oldValueFormatter) {
-                        interactiveLayer.tooltip.valueFormatter(oldValueFormatter);
+                        valueFormatter = oldValueFormatter;
                         oldValueFormatter = null;
                     }
                 }
 
-                //If we are in 'expand' mode, force the format to be a percentage.
-                var valueFormatter = (stacked.style() == 'expand') ?
-                    function(d,i) {return d == null ? "N/A" : d3.format(".1%")(d);} :
-                    interactiveLayer.tooltip.valueFormatter();
                 interactiveLayer.tooltip
                     .position({left: pointXLocation + margin.left, top: e.mouseY + margin.top})
                     .chartContainer(that.parentNode)


### PR DESCRIPTION
allowing users to set valueFormatter for interactiveLayer.tooltip (it
was previously being overwritten)

This change should also be implemented on other charts that use
interactiveLayer.tooltip

Newer iteration of #986

I believe I found a fix using the same method `yAxis.tickFormat` uses.

See [this plunk](http://plnkr.co/edit/RGxg04vhFvGl3uLTJ3Cy?p=preview).