### PR TITLE
Adding a safer version of getComputedTextLength

### DIFF
--- a/src/models/furiousLegend.js
+++ b/src/models/furiousLegend.js
@@ -178,16 +178,7 @@ nv.models.furiousLegend = function() {
                 var seriesWidths = [];
                 series.each(function(d,i) {
                     var legendText = d3.select(this).select('text');
-                    var nodeTextLength;
-                    try {
-                        nodeTextLength = legendText.node().getComputedTextLength();
-                        // If the legendText is display:none'd (nodeTextLength == 0), simulate an error so we approximate, instead
-                        if(nodeTextLength <= 0) throw Error();
-                    }
-                    catch(e) {
-                        nodeTextLength = nv.utils.calcApproxTextWidth(legendText);
-                    }
-
+                    var nodeTextLength = nv.utils.getComputedTextLength(legendText.node());
                     seriesWidths.push(nodeTextLength + padding);
                 });
 
@@ -244,7 +235,7 @@ nv.models.furiousLegend = function() {
                     xpos;
                 series
                     .attr('transform', function(d, i) {
-                        var length = d3.select(this).select('text').node().getComputedTextLength() + padding;
+                        var length = nv.utils.getComputedTextLength(d3.select(this).select('text')) + padding;
                         xpos = newxpos;
 
                         if (width < margin.left + margin.right + xpos + length) {
@@ -268,7 +259,7 @@ nv.models.furiousLegend = function() {
                 // Size rectangles after text is placed
                 seriesShape
                     .attr('width', function(d,i) {
-                        return seriesText[0][i].getComputedTextLength() + 27;
+                        return nv.utils.getComputedTextLength(seriesText[0][i]) + 27;
                     })
                     .attr('height', 18)
                     .attr('y', -9)

--- a/src/models/legend.js
+++ b/src/models/legend.js
@@ -178,16 +178,7 @@ nv.models.legend = function() {
                 var seriesWidths = [];
                 series.each(function(d,i) {
                     var legendText = d3.select(this).select('text');
-                    var nodeTextLength;
-                    try {
-                        nodeTextLength = legendText.node().getComputedTextLength();
-                        // If the legendText is display:none'd (nodeTextLength == 0), simulate an error so we approximate, instead
-                        if(nodeTextLength <= 0) throw Error();
-                    }
-                    catch(e) {
-                        nodeTextLength = nv.utils.calcApproxTextWidth(legendText);
-                    }
-
+                    var nodeTextLength = nv.utils.getComputedTextLength(legendText.node())
                     seriesWidths.push(nodeTextLength + padding);
                 });
 
@@ -244,7 +235,7 @@ nv.models.legend = function() {
                     xpos;
                 series
                     .attr('transform', function(d, i) {
-                        var length = d3.select(this).select('text').node().getComputedTextLength() + padding;
+                        var length = nv.utils.getComputedTextLength(d3.select(this).select('text').node()) + padding;
                         xpos = newxpos;
 
                         if (width < margin.left + margin.right + xpos + length) {
@@ -271,7 +262,7 @@ nv.models.legend = function() {
                 // Size rectangles after text is placed
                 seriesShape
                     .attr('width', function(d,i) {
-                        return seriesText[0][i].getComputedTextLength() + 27;
+                        return nv.utils.getComputedTextLength(seriesText[0][i]) + 27;
                     })
                     .attr('height', 18)
                     .attr('y', -9)

--- a/src/utils.js
+++ b/src/utils.js
@@ -172,6 +172,20 @@ nv.utils.calcApproxTextWidth = function (svgTextElem) {
     return 0;
 };
 
+/*
+ A safe way to get computedTextLength, since invisible elements can throw an exception if
+ svg API getComputedTextLength is called
+ */
+nv.utils.getComputedTextLength = function (svgTextElem) {
+    var length;
+    try {
+        length = svgTextElem.getComputedTextLength();
+    } catch (e) {
+        length = nv.utils.calcApproxTextWidth(svgTextElem);
+    } finally {
+        return length;
+    }
+}
 
 /*
 Numbers that are undefined, null or NaN, convert them to zeros.


### PR DESCRIPTION
Calling native getComputedTextLength on invisible elements will cause an exception ("Unexpected call to method or property access"). It can happen for several reasons. In my single page AngularJS app I got it because I was doing some DOM manipulations on promise.resolve, but user navigated to another page and then got back quickly, however the resolve code was still executing and IE threw an exception because while user went on another page the DOM has changed and text element was not there at some point. I also heard people getting this error in some scenarios using iframe, and older version of IE.
This method makes it safer to get a text length by attempting to check whether we can make this call and if not falls back to existing NVD3 method of calculating approximate text width.