### PR TITLE
creating expanded for stackedArea

### DIFF
--- a/src/models/stackedArea.js
+++ b/src/models/stackedArea.js
@@ -79,9 +79,8 @@ nv.models.stackedArea = function() {
                 .x(getX)
                 .y(getY)
                 .out(function(d, y0, y) {
-                    var yHeight = (getY(d) === 0) ? 0 : y;
                     d.display = {
-                        y: yHeight,
+                        y: y,
                         y0: y0
                     };
                 })
@@ -295,6 +294,9 @@ nv.models.stackedArea = function() {
                     chart.order('inside-out');
                     break;
                 case 'expand':
+                    chart.offset('expand');
+                    chart.order('default');
+                    break;
                 case 'stack_percent':
                     chart.offset(chart.d3_stackedOffset_stackPercent);
                     chart.order('default');


### PR DESCRIPTION
[Example plunk](http://plnkr.co/edit/yQ6iswJOJVrcmfa9n4dH?p=preview)

Differentiating between 'expand' and 'stack_percent'.
expand: all 0's --> 33.33% each
stackedPercent: all 0's --> 0% each

expand: filtering causes other series to expand to 100%
stackedPercent: filtering removes other series, but their percent values
remain the same

Accomplishes previously desired behavior without the bug in #945
An addition to #950