### PR TITLE
allowing use of forceY in stackedArea via scatter

### DIFF
--- a/src/models/stackedArea.js
+++ b/src/models/stackedArea.js
@@ -97,7 +97,13 @@ nv.models.stackedArea = function() {
             gEnter.append('g').attr('class', 'nv-scatterWrap');
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
-
+            
+            // If the user has not specified forceY, make sure 0 is included in the domain
+            // Otherwise, use user-specified values for forceY
+            if (scatter.forceY().length == 0) {
+                scatter.forceY().push(0);
+            }
+            
             scatter
                 .width(availableWidth)
                 .height(availableHeight)


### PR DESCRIPTION
Currently there is no way to use forceY on stackedArea, since stackedArea overwrites its value to [0]. This change checks if the user has provided values to forceY and only if they haven't, overwrite it with [0].

[Working Example](http://codepen.io/anon/pen/bdVdga) (Plunker seems to be down)

Solution to #602, #968, #976

Though does not allow cutting off some data from being displayed (not same as max/min) 

The underlying domain issue (described in #976) should probably still be addressed.
