### PR TITLE
Bug fixes for multiBar model

### DIFF
--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -190,7 +190,7 @@ nv.models.multiBar = function() {
                 .attr('y', function(d, i, j) {
                     var yVal = y0(0) || 0;
                     if (stacked) {
-                        if (!data[d.series].nonStackable) {
+                        if (data[d.series] && !data[d.series].nonStackable) {
                             yVal = y0(d.y0);
                         }
                     }

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -67,7 +67,6 @@ nv.models.multiBar = function() {
                 )}];
 
             if (stacked) {
-                var parsed = [];
                 var parsed = d3.layout.stack()
                     .offset(stackOffset)
                     .values(function(d){ return d.values })


### PR DESCRIPTION
- Removing duplicate declaration of 'parsed' 
- In stacked mode, clicking the lastly positioned serie's legend throws an error. It was trying to access the deleted reference. I added a null check.
