### PR TITLE
Add bower install to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ only include the source files you changed!
 
 > have node download nvd3's required modules with:  `npm install`
 
+> install bower packages with:  `bower install`
+
 > build with:  `grunt production`
 
 You should now have a `build` directory with the js and css files within.


### PR DESCRIPTION
I think that `bower install` is missing from the build instructions