### PR TITLE
bower install is required to run unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ only include the source files you changed!
 
 > have node download nvd3's required modules with:  `npm install`
 
+> install bower packages with:  `bower install`
+
 > build with:  `grunt production`
 
 You should now have a `build` directory with the js and css files within.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ only include the source files you changed!
 
 ### Tips for Testing
 * Unit tests were written in Karma and Mocha. Follow instructions in **Building Latest** to get npm packages setup. This may not work on Windows machines.
+* Run `bower install` to get bower dependencies.
 * Run `grunt` to start the unit tests.
 * Also visually inspect the HTML pages in the **examples/ and test/ folders**.  Make sure there are no glaring errors.
 * Novus now uses Travis CI for continuous integration. Visit [our travis build page](https://travis-ci.org/novus/nvd3/) to see the latest status.
@@ -122,8 +123,6 @@ only include the source files you changed!
 3. Install `grunt`, `grunt-cli`, and `bower`:  `npm install -g grunt grunt-cli bower`
 
 > have node download nvd3's required modules with:  `npm install`
-
-> install bower packages with:  `bower install`
 
 > build with:  `grunt production`
 


### PR DESCRIPTION
Correction to a closed pull request: novus/nvd3/pull/1034

liquidpele was right that `bower install` is required to run tests, not to build project