### PR TITLE
fix for issue 1025

### DIFF
--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -178,7 +178,8 @@ nv.models.scatterChart = function() {
                 .width(availableWidth)
                 .height(availableHeight)
                 .color(data.map(function(d,i) {
-                    return d.color || color(d, i);
+                    d.color = d.color || color(d, i);
+                    return d.color;
                 }).filter(function(d,i) { return !data[i].disabled }));
 
             wrap.select('.nv-scatterWrap')

--- a/test/mocha/scatter.coffee
+++ b/test/mocha/scatter.coffee
@@ -244,4 +244,4 @@ describe 'NVD3', ->
 
             builder.build options, singleData
 
-            should.exist builder.data[0].color
+            should.exist singleData[0].color

--- a/test/mocha/scatter.coffee
+++ b/test/mocha/scatter.coffee
@@ -231,3 +231,17 @@ describe 'NVD3', ->
 
             builder.svg.querySelector('.nv-wrap.nv-scatter')
             .className.should.contain 'nv-single-point'
+
+        it 'should set color property if not specified', ->
+            builder.teardown()
+
+            singleData = [
+                key: 'Series1'
+                values: [
+                  [1,1]
+                ]
+            ]
+
+            builder.build options, singleData
+
+            should.exist builder.data[0].color

--- a/test/mocha/test-utils.coffee
+++ b/test/mocha/test-utils.coffee
@@ -12,7 +12,6 @@ class ChartBuilder
     This method builds a chart and puts it on the <body> element.
     ###
     build: (options, data)->
-        @data = data
         @svg = document.createElement 'svg'
         document.querySelector('body').appendChild @svg
 
@@ -28,7 +27,6 @@ class ChartBuilder
     Update the data while preserving the chart model.
     ###
     updateData: (data)->
-        @data = data
         d3.select(@svg).datum(data).call(@model)
 
     ###
@@ -40,7 +38,6 @@ class ChartBuilder
     Useful for testing the results of transitioning and the 'noData' state after a chart has had data
     ###
     buildover: (options, data, data2)->
-        @data = data
         @svg = document.createElement 'svg'
         document.querySelector('body').appendChild @svg
 

--- a/test/mocha/test-utils.coffee
+++ b/test/mocha/test-utils.coffee
@@ -12,6 +12,7 @@ class ChartBuilder
     This method builds a chart and puts it on the <body> element.
     ###
     build: (options, data)->
+        @data = data
         @svg = document.createElement 'svg'
         document.querySelector('body').appendChild @svg
 
@@ -27,6 +28,7 @@ class ChartBuilder
     Update the data while preserving the chart model.
     ###
     updateData: (data)->
+        @data = data
         d3.select(@svg).datum(data).call(@model)
 
     ###
@@ -38,6 +40,7 @@ class ChartBuilder
     Useful for testing the results of transitioning and the 'noData' state after a chart has had data
     ###
     buildover: (options, data, data2)->
+        @data = data
         @svg = document.createElement 'svg'
         document.querySelector('body').appendChild @svg
 


### PR DESCRIPTION
I was able to reproduce #1025 reliably with these steps:

1. Use a data object where each series does not have a `color` attribute set (ex. series A, B, C)
2. Hover over a point from series A to display the tooltip
3. Cause a chart update (clicking a legend item, resizing the browser window)
4. All colors will shift to the right (B has A's color and C has B's color)

The problem:

The tooltip function needs a series color to display, so it sets the series A color using the color(d, i) function.

Then, when the chart is updated, series A has a color. In the current scatterChart model, if a series has a color then the color function is not called. So, color(d, i) is called for the first time to get the color for series B. Thus, B gets the first color (the color that A had on the first draw).

I think the best solution is just to set the series color if one does not exist. Then, we don't have to worry about series colors getting out of sync if a color is set later on.

A unit test is included that makes sure a color is set if none is specified. It fails without the pull request and passes after.

Thanks for reviewing, nvd3 is a great library!