### PR TITLE
created an option to configure the number of ticks for bulletChart

### DIFF
--- a/src/models/bulletChart.js
+++ b/src/models/bulletChart.js
@@ -21,6 +21,7 @@ nv.models.bulletChart = function() {
         , width = null
         , height = 55
         , tickFormat = null
+	, ticks = null
         , noData = null
         , dispatch = d3.dispatch('tooltipShow', 'tooltipHide')
         ;
@@ -102,7 +103,7 @@ nv.models.bulletChart = function() {
 
             // Update the tick groups.
             var tick = g.selectAll('g.nv-tick')
-                .data(x1.ticks( availableWidth / 50 ), function(d) {
+                .data(x1.ticks( ticks ? ticks : (availableWidth / 50) ), function(d) {
                     return this.textContent || format(d);
                 });
 
@@ -184,6 +185,7 @@ nv.models.bulletChart = function() {
         width:    {get: function(){return width;}, set: function(_){width=_;}},
         height:    {get: function(){return height;}, set: function(_){height=_;}},
         tickFormat:    {get: function(){return tickFormat;}, set: function(_){tickFormat=_;}},
+        ticks:    {get: function(){return ticks;}, set: function(_){ticks=_;}},
         noData:    {get: function(){return noData;}, set: function(_){noData=_;}},
 
         // deprecated options


### PR DESCRIPTION
This is an enhancement resolving #1052

I have to idea how to write a test for this, sorry about that.

One thing I've noticed that the number of ticks won't be exact in some cases.
I've tried the bulletChart example (the last one with custom labels) with
ticks(2) -> result is 2 ticks
ticks(3) -> result is 4 ticks
ticks(5) -> result is 7 ticks
ticks(10) -> result is 7 ticks
ticks(20) -> result is 16 ticks
ticks(30) -> result is 30 ticks

I assume it is related to the d3.js ticks function. 