### PR TITLE
Add ability to change lwfc focus graph margins

### DIFF
--- a/examples/lineWithFocusChart_x2AxisLabel.html
+++ b/examples/lineWithFocusChart_x2AxisLabel.html
@@ -35,8 +35,10 @@
 
         chart.brushExtent([50,70]);
 
-        chart.xAxis.tickFormat(d3.format(',f')).axisLabel("Stream - 3,128,.1");
-        chart.x2Axis.tickFormat(d3.format(',f'));
+        chart.xAxis.tickFormat(d3.format(',f'));
+        chart.focusHeight(50 + 20);
+        chart.focusMargin({ "bottom": 20 + 20 });
+        chart.x2Axis.tickFormat(d3.format(',f')).axisLabel("Stream - 3,128,.1");
         chart.yAxis.tickFormat(d3.format(',.2f'));
         chart.y2Axis.tickFormat(d3.format(',.2f'));
         chart.useInteractiveGuideline(true);

--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -575,6 +575,12 @@ nv.models.linePlusBarChart = function() {
             margin.bottom = _.bottom !== undefined ? _.bottom : margin.bottom;
             margin.left   = _.left   !== undefined ? _.left   : margin.left;
         }},
+        focusMargin: {get: function(){return margin2;}, set: function(_){
+            margin2.top    = _.top    !== undefined ? _.top    : margin2.top;
+            margin2.right  = _.right  !== undefined ? _.right  : margin2.right;
+            margin2.bottom = _.bottom !== undefined ? _.bottom : margin2.bottom;
+            margin2.left   = _.left   !== undefined ? _.left   : margin2.left;
+        }},
         duration: {get: function(){return transitionDuration;}, set: function(_){
             transitionDuration = _;
         }},

--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -496,6 +496,12 @@ nv.models.lineWithFocusChart = function() {
             margin.bottom = _.bottom !== undefined ? _.bottom : margin.bottom;
             margin.left   = _.left   !== undefined ? _.left   : margin.left;
         }},
+        focusMargin: {get: function(){return margin2;}, set: function(_){
+            margin2.top    = _.top    !== undefined ? _.top    : margin2.top;
+            margin2.right  = _.right  !== undefined ? _.right  : margin2.right;
+            margin2.bottom = _.bottom !== undefined ? _.bottom : margin2.bottom;
+            margin2.left   = _.left   !== undefined ? _.left   : margin2.left;
+        }},
         color:  {get: function(){return color;}, set: function(_){
             color = nv.utils.getColor(_);
             legend.color(color);


### PR DESCRIPTION
If one would want to place an x-axis label below both the graph and its
focus graph, prior to this patch it is not possible in a fixed height
setting, as there is no way to change the bottom margin to account for
a label.

This change adds the ability to change the bottom margin.  Note that in
order for that label to work while maintaining the focus graph height,
one also has to up the "focusHeight" value.