### PR TITLE
Change sparklinePlus update function to be consistent with other models

### DIFF
--- a/src/models/sparklinePlus.js
+++ b/src/models/sparklinePlus.js
@@ -31,7 +31,7 @@ nv.models.sparklinePlus = function() {
             var availableWidth = nv.utils.availableWidth(width, container, margin),
                 availableHeight = nv.utils.availableHeight(height, container, margin);
 
-            chart.update = function() { chart(selection) };
+            chart.update = function() { container.call(chart); };
             chart.container = this;
 
             // Display No Data message if there's nothing to show.


### PR DESCRIPTION
Hello... I'm not entirely sure why, but the old sparklinePlus update code was causing the error "cannot read property '1' of undefined" in our application when I would bind resize to chart update `nv.utils.windowResize(chart.update);`.  In this case, it would work on first load but on resize the error would occur. Changing the function to be consistent with the other models and use `container.call(chart);`  fixes the issue in our app.

[Here](http://rreinhardt9.github.io/d3_workshop/broken_sparkline.html) is a mockup using the latest on the development branch; open up the console and then resize the window and you'll see what I mean. This is pretty much the example form the sparklinePlus example page, but I added `.transition()` before calling the chart. Adding this is what seems to cause the issue; the reason it is getting called on the sparkline in our context is that we reuse the same code to call all of our nvd3 chart models. From what I can ascertain, the selection that is passed to chart in `chart(selection)` was different than on first load. When it was called in update, the error was originating from `container.each` on [line 27](https://github.com/novus/nvd3/blob/development/src/models/sparklinePlus.js#L27); specifically, it was looking for a namespace on the node in `.each` called  `"__transition__"` and this is what was undefined for the selection that was passed in the update function.

Not entirely sure what was happening there, but at least is seems calling `.transition()` on the sparkline model doesn't work well with the current update function; and while you could potentially just not do that, it would be nice to have it behave like the other models for situations like ours where we reuse code across the models. 

All this description for a one line change :-)
Thanks!