### PR TITLE
Added 'TOTAL' to stackedAreaChart tooltip.

### DIFF
--- a/src/css/tooltip.css
+++ b/src/css/tooltip.css
@@ -87,7 +87,10 @@
 }
 
 .nvtooltip table td.key {
-    font-weight:normal;
+    font-weight: normal;
+}
+.nvtooltip table td.key.total {
+    font-weight: bold;
 }
 .nvtooltip table td.value {
     text-align: right;

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -342,7 +342,7 @@ nv.models.stackedAreaChart = function() {
 
             interactiveLayer.dispatch.on('elementMousemove', function(e) {
                 stacked.clearHighlights();
-                var singlePoint, pointIndex, pointXLocation, allData = [];
+                var singlePoint, pointIndex, pointXLocation, allData = [], valueSum = 0;
                 data
                     .filter(function(series, i) {
                         series.seriesIndex = i;
@@ -367,6 +367,8 @@ nv.models.stackedAreaChart = function() {
                             color: color(series,series.seriesIndex),
                             stackedValue: point.display
                         });
+
+                        valueSum += tooltipValue;
                     });
 
                 allData.reverse();
@@ -390,6 +392,15 @@ nv.models.stackedAreaChart = function() {
                     });
                     if (indexToHighlight != null)
                         allData[indexToHighlight].highlight = true;
+                }
+
+                //If we are not in 'expand' mode, add a 'Total' row to the tooltip.
+                if (stacked.style() != 'expand' && allData.length >= 2) {
+                    allData.push({
+                        key: "TOTAL",
+                        value: valueSum,
+                        total: true
+                    });
                 }
 
                 var xValue = xAxis.tickFormat()(chart.x()(singlePoint,pointIndex));

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -25,6 +25,8 @@ nv.models.stackedAreaChart = function() {
         , showYAxis = true
         , rightAlignYAxis = false
         , useInteractiveGuideline = false
+        , showTotalInTooltip = true
+        , totalLabel = 'TOTAL'
         , x //can be accessed via chart.xScale()
         , y //can be accessed via chart.yScale()
         , state = nv.utils.state()
@@ -395,9 +397,9 @@ nv.models.stackedAreaChart = function() {
                 }
 
                 //If we are not in 'expand' mode, add a 'Total' row to the tooltip.
-                if (stacked.style() != 'expand' && allData.length >= 2) {
+                if (showTotalInTooltip && stacked.style() != 'expand' && allData.length >= 2) {
                     allData.push({
-                        key: "TOTAL",
+                        key: totalLabel,
                         value: valueSum,
                         total: true
                     });
@@ -508,6 +510,8 @@ nv.models.stackedAreaChart = function() {
         showControls:    {get: function(){return showControls;}, set: function(_){showControls=_;}},
         controlLabels:    {get: function(){return controlLabels;}, set: function(_){controlLabels=_;}},
         controlOptions:    {get: function(){return controlOptions;}, set: function(_){controlOptions=_;}},
+        showTotalInTooltip:      {get: function(){return showTotalInTooltip;}, set: function(_){showTotalInTooltip=_;}},
+        totalLabel:      {get: function(){return totalLabel;}, set: function(_){totalLabel=_;}},
 
         // deprecated options
         tooltips:    {get: function(){return tooltip.enabled();}, set: function(_){

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -370,7 +370,9 @@ nv.models.stackedAreaChart = function() {
                             stackedValue: point.display
                         });
 
-                        valueSum += tooltipValue;
+                        if (showTotalInTooltip && stacked.style() != 'expand') {
+                          valueSum += tooltipValue;
+                        };
                     });
 
                 allData.reverse();

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -109,7 +109,8 @@
 
             trowEnter.append("td")
                 .classed("key",true)
-                .html(function(p, i) {return keyFormatter(p.key, i)});
+                .html(function(p, i) {return keyFormatter(p.key, i)})
+                .style("font-weight", function(p) {return p.total && "bold"});
 
             trowEnter.append("td")
                 .classed("value",true)
@@ -233,7 +234,7 @@
                         tTop = tooltipTop(tooltipElem);
                         break;
                 }
-                
+
                 // adjust tooltip offsets
                 left -= offset.left;
                 top -= offset.top;
@@ -264,7 +265,7 @@
                         .styleTween('transform', function (d) {
                             return translateInterpolator;
                         }, 'important')
-                        // Safari has its own `-webkit-transform` and does not support `transform` 
+                        // Safari has its own `-webkit-transform` and does not support `transform`
                         // transform tooltip without transition only in Safari
                         .style('-webkit-transform', new_translate)
                         .style('opacity', 1);

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -109,8 +109,8 @@
 
             trowEnter.append("td")
                 .classed("key",true)
-                .html(function(p, i) {return keyFormatter(p.key, i)})
-                .style("font-weight", function(p) {return p.total && "bold"});
+                .classed("total",function(p) { return !!p.total})
+                .html(function(p, i) { return keyFormatter(p.key, i)});
 
             trowEnter.append("td")
                 .classed("value",true)


### PR DESCRIPTION
Stacked area plots are used when you want to understand how various parts add up to a whole, and how this breakdown varies with respect to some *x* dimension. So you often want to know what the whole is. This change adds a **TOTAL** row at the bottom of the `stackedAreaChart` tooltip.

`examples/stackedAreaChart.html` works well and looks like:

![screen shot 2015-06-24 at 2 25 31 pm](https://cloud.githubusercontent.com/assets/6334419/8341871/f9d74ff2-1a7c-11e5-850e-e961866116c4.png)