### PR TITLE
Fixed wrong bar color changes in multiBar when a group is disabled

### DIFF
--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -241,8 +241,6 @@ nv.models.multiBar = function() {
             barsEnter.append('rect')
                     .attr('height', 0)
                     .attr('width', function(d,i,j) { return x.rangeBand() / (stacked && !data[j].nonStackable ? 1 : data.length) })
-                    .style('fill', function(d,i,j){ return color(d, j, i);  })
-                    .style('stroke', function(d,i,j){ return color(d, j, i); })
                 ;
             bars
                 .on('mouseover', function(d,i) { //TODO: figure out why j works above, but not here


### PR DESCRIPTION
When a group is disabled in a multiBarChart (e.g. the first group in the multiBarChart2 example) the bar color for each group is changed but the color in the legend and tooltip is not. 

![screenshot](https://cloud.githubusercontent.com/assets/386914/8451521/2a129f84-1fe4-11e5-97ca-c9c804424da1.png)

For reference: The change was introduced in 0d7c737 

Previously the removed lines were in the 

    bars.
        .on('mouseover', function(d,i) {

lines but in my tests it does not make any difference if the lines are removed or moved back to the old position. Therefore I decided to remove them. 