### PR TITLE
Fixed the typeError when selecting an area of a stacked area graph.

### DIFF
--- a/build/nv.d3.js
+++ b/build/nv.d3.js
@@ -12324,7 +12324,10 @@ nv.models.stackedArea = function() {
                 .width(availableWidth)
                 .height(availableHeight)
                 .x(getX)
-                .y(function(d) { return d.display.y + d.display.y0 })
+                .y(function(d) {
+                  if( typeof d.display === 'undefined' ) {}
+                  else { return d.display.y + d.display.y0 }
+                })
                 .forceY([0])
                 .color(data.map(function(d,i) {
                     return d.color || color(d, d.seriesIndex);


### PR DESCRIPTION
I just added a simple check in the scatter.y function to ignore all d objects that are not point objects. This is the fix for issue #1193.