### PR TITLE
Added maxKeyLength variable to truncate legend key values.

### DIFF
--- a/examples/furiousLegend.html
+++ b/examples/furiousLegend.html
@@ -94,7 +94,7 @@
     function sinAndCos() {
         return [
             {key: "Sine Wave"},
-            {key: "A Very Long Series Label"},
+            {key: "averylongserieslabelthatcontainsmorethantwentycharacters"},
             {key: "A Very Long Series Label"},
             {key: "A Very Long Series Label"},
             {key: "Cosine Wave"},

--- a/examples/legend.html
+++ b/examples/legend.html
@@ -81,9 +81,9 @@
     function sinAndCos() {
         return [
             {key: "Sine Wave"},
-            {key: "A Very Long Series Label"},
-            {key: "A Very Long Series Label"},
-            {key: "A Very Long Series Label"},
+            {key: "A Very Long Label With Over Twenty Characters"},
+            {key: "A Very Long Series Label With Over Twenty Characters"},
+            {key: "A Very Long Series Label With Over Twenty Characters"},
             {key: "Cosine Wave"},
             {key: "Another test label"}
         ];

--- a/src/models/furiousLegend.js
+++ b/src/models/furiousLegend.js
@@ -10,6 +10,7 @@ nv.models.furiousLegend = function() {
         , height = 20
         , getKey = function(d) { return d.key }
         , color = nv.utils.getColor()
+        , maxKeyLength = 20 //default value for key lengths
         , align = true
         , padding = 28 //define how much space between legend items. - recommend 32 for furious version
         , rightAlign = true
@@ -177,7 +178,14 @@ nv.models.furiousLegend = function() {
 
                 var seriesWidths = [];
                 series.each(function(d,i) {
-                    var legendText = d3.select(this).select('text');
+                    var legendText;
+                    if (getKey(d).length > maxKeyLength) { 
+                        var trimmedKey = getKey(d).substring(0, maxKeyLength);
+                        legendText = d3.select(this).select('text').text(trimmedKey + "...");
+                        d3.select(this).append("svg:title").text(getKey(d));
+                    } else {
+                        legendText = d3.select(this).select('text');
+                    } 
                     var nodeTextLength;
                     try {
                         nodeTextLength = legendText.node().getComputedTextLength();
@@ -314,6 +322,7 @@ nv.models.furiousLegend = function() {
         key:        {get: function(){return getKey;}, set: function(_){getKey=_;}},
         align:      {get: function(){return align;}, set: function(_){align=_;}},
         rightAlign:    {get: function(){return rightAlign;}, set: function(_){rightAlign=_;}},
+        maxKeyLength:  {get: function(){return maxKeyLength;}, set: function(_){maxKeyLength=_;}},
         padding:       {get: function(){return padding;}, set: function(_){padding=_;}},
         updateState:   {get: function(){return updateState;}, set: function(_){updateState=_;}},
         radioButtonMode:    {get: function(){return radioButtonMode;}, set: function(_){radioButtonMode=_;}},

--- a/src/models/legend.js
+++ b/src/models/legend.js
@@ -10,6 +10,7 @@ nv.models.legend = function() {
         , height = 20
         , getKey = function(d) { return d.key }
         , color = nv.utils.getColor()
+        , maxKeyLength = 20 //default value for key lengths
         , align = true
         , padding = 32 //define how much space between legend items. - recommend 32 for furious version
         , rightAlign = true
@@ -67,7 +68,6 @@ nv.models.legend = function() {
                     .attr('class','nv-legend-symbol')
                     .attr('rx', 3)
                     .attr('ry', 3);
-
                 seriesShape = series.select('.nv-legend-symbol');
 
                 seriesEnter.append('g')
@@ -177,7 +177,14 @@ nv.models.legend = function() {
 
                 var seriesWidths = [];
                 series.each(function(d,i) {
-                    var legendText = d3.select(this).select('text');
+                    var legendText;
+                    if (getKey(d).length > maxKeyLength) { 
+                        var trimmedKey = getKey(d).substring(0, maxKeyLength);
+                        legendText = d3.select(this).select('text').text(trimmedKey + "...");
+                        d3.select(this).append("svg:title").text(getKey(d));
+                    } else {
+                        legendText = d3.select(this).select('text');
+                    } 
                     var nodeTextLength;
                     try {
                         nodeTextLength = legendText.node().getComputedTextLength();
@@ -346,6 +353,7 @@ nv.models.legend = function() {
         height:     {get: function(){return height;}, set: function(_){height=_;}},
         key:        {get: function(){return getKey;}, set: function(_){getKey=_;}},
         align:      {get: function(){return align;}, set: function(_){align=_;}},
+        maxKeyLength:   {get: function(){return maxKeyLength;}, set: function(_){maxKeyLength=_;}},
         rightAlign:    {get: function(){return rightAlign;}, set: function(_){rightAlign=_;}},
         padding:       {get: function(){return padding;}, set: function(_){padding=_;}},
         updateState:   {get: function(){return updateState;}, set: function(_){updateState=_;}},

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -115,7 +115,6 @@
                 .classed("value",true)
                 .html(function(p, i) { return valueFormatter(p.value, i) });
 
-
             trowEnter.selectAll("td").each(function(p) {
                 if (p.highlight) {
                     var opacityScale = d3.scale.linear().domain([0,1]).range(["#fff",p.color]);


### PR DESCRIPTION
This fix provides an additional variable to set a fixed max key length
value to truncate any legend key values with lengths over the specified
threshold. This provides the option to organize legend keys to be seen
in a more readable manner.

Added tooltip for truncated legend text.
When mousing over truncated text within the legend,
a tooltip showing the full key value is revealed.