### PR TITLE
Fixed TypeError bug when a user clicks on an area of a stacked area chart, Issue #1093

### DIFF
--- a/src/models/stackedArea.js
+++ b/src/models/stackedArea.js
@@ -110,7 +110,9 @@ nv.models.stackedArea = function() {
                 .width(availableWidth)
                 .height(availableHeight)
                 .x(getX)
-                .y(function(d) { return d.display.y + d.display.y0 })
+                .y(function(d) {
+                    if (d.display !== undefined) { return d.display.y + d.display.y0; }
+                })
                 .forceY([0])
                 .color(data.map(function(d,i) {
                     return d.color || color(d, d.seriesIndex);


### PR DESCRIPTION
Fix for Issue #1093, still get warnings when a user clicks on an area in the chart but no errors occur and all functionality is there.