### PR TITLE
tooltip-fix

### DIFF
--- a/build/nv.d3.js
+++ b/build/nv.d3.js
@@ -678,7 +678,7 @@ nv.nearestValueIndex = function (values, searchVal, threshold) {
                         tLeft = tooltipLeft(tooltipElem);
                         tTop = tooltipTop(tooltipElem);
                         if (tLeft + width > windowWidth) left = pos[0] - width - distance;
-                        if (tTop < scrollTop) top = scrollTop + 5;
+                        if (tTop < scrollTop) top = scrollTop - tTop + top;
                         if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
                         break;
                     case 'n':


### PR DESCRIPTION
This is a one-line fix to Issue #1124.  As I said there, the tooltip with 'w' gravity was jumping down when it hit the top of the window, instead of staying at the top.  (The problem did not exist when the tooltip hit the bottom of the window).  

If you look at the switch statement that calculates the 'top' for each of the four gravity types, it's pretty clear that the 'top' formula for 'w' was accidentally taken from the 'left' formula for 'n' and 's'.   My fix simply makes the 'top' formula for 'w' the same as the 'top' formula for 'e'.  

Before and after pics are attached.  The important points in the pics are the location of the mouse vs. the location of the tooltip.

Thanks much,
Jake

<img width="907" alt="after" src="https://cloud.githubusercontent.com/assets/9143823/8682009/8b244a94-2a1f-11e5-8fac-7287f738d8f2.png">
<img width="907" alt="before" src="https://cloud.githubusercontent.com/assets/9143823/8682014/8ea578c8-2a1f-11e5-90ba-5d93123d70e2.png">