### PR TITLE
initial commit (to src instead of build)

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -206,7 +206,7 @@
                         tLeft = tooltipLeft(tooltipElem);
                         tTop = tooltipTop(tooltipElem);
                         if (tLeft + width > windowWidth) left = pos[0] - width - distance;
-                        if (tTop < scrollTop) top = scrollTop + 5;
+                        if (tTop < scrollTop) top = scrollTop - tTop + top;
                         if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
                         break;
                     case 'n':


### PR DESCRIPTION
Okay, I'm trying this again after fixing that build issue.

This is a one-line fix for Issue #1124. As I said there, the tooltip with 'w' gravity was jumping down when it hit the top of the window, instead of staying at the top. (The problem did not exist when the tooltip hit the bottom of the window).

If you look at the switch statement that calculates the 'top' for each of the four gravity types, it's pretty clear that the 'top' formula for 'w' was accidentally taken from the 'left' formula for 'n' and 's'. My fix simply makes the 'top' formula for 'w' the same as the 'top' formula for 'e'.

Before and after pics are attached. The important points in the pics are the location of the mouse vs. the location of the tooltip.

Thanks much,
Jake

Before: tooltip jumping down when it hits top of window
<img width="907" alt="before" src="https://cloud.githubusercontent.com/assets/9143823/8683167/0820da20-2a26-11e5-8e0b-93db0c37d00c.png">

After: tooltip hugs top of window
<img width="907" alt="after" src="https://cloud.githubusercontent.com/assets/9143823/8683181/19a45a06-2a26-11e5-9d4a-9368f1ade67b.png">


