### PR TITLE
Meteor: Specify package which matches git tag

### DIFF
--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@
 Package.describe({
     "name": 'nvd3:nvd3',
     summary: 'Nvd3.org charts.',
-    version: '1.8.1-dev',
+    version: '1.8.1',
     git: "https://github.com/novus/nvd3.git"
 });
 Package.on_use(function (api) {


### PR DESCRIPTION
I think meteor's atmosphere is still showing version 1.7.1 because the package `1.8.1-dev` does not exist as a tag or branch on this repository. I think this change will allow meteor to update to 1.8.1, but I'm not 100% sure. Anyway, it seems sensible to have a version number which exists rather than one which does not, so the change won't do any harm.