### PR TITLE
Add case 'center' to calcTooltipPosition.

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -233,6 +233,12 @@
                         tLeft = tooltipLeft(tooltipElem);
                         tTop = tooltipTop(tooltipElem);
                         break;
+                    case 'center':
+                        left = pos[0] - (width / 2);
+                        top = pos[1] - (height / 2);
+                        tLeft = tooltipLeft(container);
+                        tTop = tooltipTop(container);
+                        break;
                 }
 
                 // adjust tooltip offsets


### PR DESCRIPTION
Add case 'center' for the tooltip showing. Useful when user want to show the tooltip center.