### PR TITLE
Documentation Fix for Default Margins

### DIFF
--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -177,10 +177,10 @@
 
                         var desc = option_info[name]['desc'];
                         var def;
-                        if (typeof option_info[name]['default'] == 'function') {
-                            // use function in option_info to pull default value of the option off an instance of the chart
+                        // if defaultValueGetter exists, it is a function to pull the actual default value from an instance of the chart
+                        if (option_info[name]['defaultValueGetter']) { 
                             var chartName = a.parent().attr('id').substring(3); // first 3 chars are a 'ul_' appended to the chart name
-                            def = JSON.stringify(option_info[name]['default'](nv.models[chartName]()), null, 1);
+                            def = JSON.stringify(option_info[name]['defaultValueGetter'](nv.models[chartName]()), null, 1);
                         } else {
                             def = option_info[name]['default'];
                         }
@@ -386,7 +386,7 @@ as well as used to print out examples using those example inputs.
         },
         margin: {
             desc: "Object containing the margins for the chart or component.  You can specify only certain margins in the object to change just those parts.",
-            default: function(chart){ return chart.margin(); },
+            defaultValueGetter: function(chart){ return chart.margin(); },
             examples: [
                 {top: 10, bottom: 10},
                 {left: 5, right: 5, top: 10, bottom: 10}

--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -173,8 +173,17 @@
                     var info = '';
                     if (option_info[name]) {
 
+
+
                         var desc = option_info[name]['desc'];
-                        var def = option_info[name]['default'];
+                        var def;
+                        if (typeof option_info[name]['default'] == 'function') {
+                            // use function in option_info to pull default value of the option off an instance of the chart
+                            var chartName = a.parent().attr('id').substring(3); // first 3 chars are a 'ul_' appended to the chart name
+                            def = JSON.stringify(option_info[name]['default'](nv.models[chartName]()), null, 1);
+                        } else {
+                            def = option_info[name]['default'];
+                        }
                         var ex = option_info[name]['examples'];
                         var refs = option_info[name]['refs'] || [];
                         var example_obj = option_info[name]['example_object'] || 'chart';
@@ -377,7 +386,7 @@ as well as used to print out examples using those example inputs.
         },
         margin: {
             desc: "Object containing the margins for the chart or component.  You can specify only certain margins in the object to change just those parts.",
-            default: "0 for all margins",
+            default: function(chart){ return chart.margin(); },
             examples: [
                 {top: 10, bottom: 10},
                 {left: 5, right: 5, top: 10, bottom: 10}

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -43,7 +43,8 @@
             ,   offset = {left: 0, top: 0}   //Offset of tooltip against the pointer
             ,   enabled = true  //True -> tooltips are rendered. False -> don't render tooltips.
             ,   duration = 100 // duration for tooltip movement
-            ,   headerEnabled = true
+            ,   headerEnabled = true //show the tooltip header
+            ,   legendEnabled = true //show the tooltip legend
         ;
 
         // set to true by interactive layer to adjust tooltip positions
@@ -86,7 +87,7 @@
 
                 theadEnter.append("tr")
                     .append("td")
-                    .attr("colspan", 3)
+                    .attr("colspan", legendEnabled ? 3 : 2)
                     .append("strong")
                     .classed("x-value", true)
                     .html(headerFormatter(d.value));
@@ -102,10 +103,12 @@
                     .append("tr")
                     .classed("highlight", function(p) { return p.highlight});
 
-            trowEnter.append("td")
-                .classed("legend-color-guide",true)
-                .append("div")
-                .style("background-color", function(p) { return p.color});
+            if (legendEnabled) {
+                trowEnter.append("td")
+                    .classed("legend-color-guide",true)
+                    .append("div")
+                    .style("background-color", function(p) { return p.color});
+            }
 
             trowEnter.append("td")
                 .classed("key",true)
@@ -393,6 +396,7 @@
             headerFormatter: {get: function(){return headerFormatter;}, set: function(_){headerFormatter=_;}},
             keyFormatter: {get: function(){return keyFormatter;}, set: function(_){keyFormatter=_;}},
             headerEnabled:   {get: function(){return headerEnabled;}, set: function(_){headerEnabled=_;}},
+            legendEnabled:   {get: function(){return legendEnabled;}, set: function(_){legendEnabled=_;}},
 
             // internal use only, set by interactive layer to adjust position.
             _isInteractiveLayer: {get: function(){return isInteractiveLayer;}, set: function(_){isInteractiveLayer=!!_;}},

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -43,8 +43,7 @@
             ,   offset = {left: 0, top: 0}   //Offset of tooltip against the pointer
             ,   enabled = true  //True -> tooltips are rendered. False -> don't render tooltips.
             ,   duration = 100 // duration for tooltip movement
-            ,   headerEnabled = true //show the tooltip header
-            ,   legendEnabled = true //show the tooltip legend
+            ,   headerEnabled = true
         ;
 
         // set to true by interactive layer to adjust tooltip positions
@@ -87,7 +86,7 @@
 
                 theadEnter.append("tr")
                     .append("td")
-                    .attr("colspan", legendEnabled ? 3 : 2)
+                    .attr("colspan", 3)
                     .append("strong")
                     .classed("x-value", true)
                     .html(headerFormatter(d.value));
@@ -103,12 +102,10 @@
                     .append("tr")
                     .classed("highlight", function(p) { return p.highlight});
 
-            if (legendEnabled) {
-                trowEnter.append("td")
-                    .classed("legend-color-guide",true)
-                    .append("div")
-                    .style("background-color", function(p) { return p.color});
-            }
+            trowEnter.append("td")
+                .classed("legend-color-guide",true)
+                .append("div")
+                .style("background-color", function(p) { return p.color});
 
             trowEnter.append("td")
                 .classed("key",true)
@@ -396,7 +393,6 @@
             headerFormatter: {get: function(){return headerFormatter;}, set: function(_){headerFormatter=_;}},
             keyFormatter: {get: function(){return keyFormatter;}, set: function(_){keyFormatter=_;}},
             headerEnabled:   {get: function(){return headerEnabled;}, set: function(_){headerEnabled=_;}},
-            legendEnabled:   {get: function(){return legendEnabled;}, set: function(_){legendEnabled=_;}},
 
             // internal use only, set by interactive layer to adjust position.
             _isInteractiveLayer: {get: function(){return isInteractiveLayer;}, set: function(_){isInteractiveLayer=!!_;}},


### PR DESCRIPTION
The documentation says the default margin for all charts is 0 in all dimensions - which isn't correct.

This change instantiates the chart and pulls the default margin off of it, and then serializes that to a string to show as the documentation.

This pattern could probably be used for some other pieces of documentation, but I don't have an exhaustive enough knowledge of the library to know where it would be useful.