### PR TITLE
Fixed tooltip transform style interpolation issue under Safari

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -273,7 +273,7 @@
                         // Safari has its own `-webkit-transform` and does not support `transform`
                         .styleTween('-webkit-transform', function (d) {
                             return translateInterpolator;
-                        }, 'important')
+                        })
                         .style('-ms-transform', new_translate)
                         .style('opacity', 1);
                 }

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -271,8 +271,9 @@
                             return translateInterpolator;
                         }, 'important')
                         // Safari has its own `-webkit-transform` and does not support `transform`
-                        // transform tooltip without transition only in Safari
-                        .style('-webkit-transform', new_translate)
+                        .styleTween('-webkit-transform', function (d) {
+                            return translateInterpolator;
+                        }, 'important')
                         .style('-ms-transform', new_translate)
                         .style('opacity', 1);
                 }


### PR DESCRIPTION
Added extra tween for the -webkit-transform style attribute, so that in Safari (and Qt5.3+ applications using Qt webkit), the tooltips do not appear to fly in from the origin. This does not appear to impact other browsers in any way. 

Could not find an existing test for this, so please let me know if one needs to be added and where.