### PR TITLE
BugFix: Don't loose classed for main chart in lineWithFocusChart

### DIFF
--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -417,6 +417,7 @@ nv.models.lineWithFocusChart = function() {
                             return {
                                 key: d.key,
                                 area: d.area,
+                                classed: d.classed,
                                 values: d.values.filter(function(d,i) {
                                     return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
                                 })


### PR DESCRIPTION
Classed was only being applied to the focus control chart and lost on the main chart as it was overwritten. This bug fix allows styling of the line series in the main chart.

Prior to Bug Fix:
![image](https://cloud.githubusercontent.com/assets/5879373/9503128/2487b892-4c03-11e5-9df5-1bbb33845a5c.png)

Fixed:
![image](https://cloud.githubusercontent.com/assets/5879373/9503348/53e56bec-4c04-11e5-967b-35daa46d13e2.png)


