### PR TITLE
return 0 when the y value is undefined

### DIFF
--- a/src/models/multiBarHorizontal.js
+++ b/src/models/multiBarHorizontal.js
@@ -269,7 +269,7 @@ nv.models.multiBarHorizontal = function() {
                     })
                     .select('rect')
                     .attr('width', function(d,i) {
-                        return Math.abs(y(getY(d,i) + d.y0) - y(d.y0))
+                        return Math.abs(y(getY(d,i) + d.y0) - y(d.y0)) || 0
                     })
                     .attr('height', x.rangeBand() );
             else
@@ -287,7 +287,7 @@ nv.models.multiBarHorizontal = function() {
                     .select('rect')
                     .attr('height', x.rangeBand() / data.length )
                     .attr('width', function(d,i) {
-                        return Math.max(Math.abs(y(getY(d,i)) - y(0)),1)
+                        return Math.max(Math.abs(y(getY(d,i)) - y(0)),1) || 0
                     });
 
             //store old scales for use in transitions on update


### PR DESCRIPTION
This commit is related with the issue :
Multibarhorizontal show width 1 when the data is undefined, I think that the width should be 0 #1216