### PR TITLE
Add series data to allData in lineChart.

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -236,7 +236,8 @@ nv.models.lineChart = function() {
                         allData.push({
                             key: series.key,
                             value: pointYValue,
-                            color: color(series,series.seriesIndex)
+                            color: color(series,series.seriesIndex),
+                            data: series.values[pointIndex]
                         });
                     });
                 //Highlight the tooltip entry based on which point the mouse is closest to.


### PR DESCRIPTION
`historicalBarChart` has this data but it was missing in the lineChart.
Adding this enables the use of that data when creating a custom tooltip.

Here's a example.
```js
var tsFormat = d3.time.format('%b %-d, %Y %I:%M%p');
var contentGenerator = chart.interactiveLayer.tooltip.contentGenerator();
var tooltip = chart.interactiveLayer.tooltip;
tooltip.contentGenerator(function (d) { d.value = d.series[0].data.x; return contentGenerator(d); });
tooltip.headerFormatter(function (d) { return tsFormat(new Date(d)); });
```

Notice the `d.value = d.series[0].data.x` in the `tooltip.contentGenerator`, this was not available before in the lineChart.

