### PR TITLE
Fixed bug when yDomain[0] is negative

### DIFF
--- a/src/models/discreteBar.js
+++ b/src/models/discreteBar.js
@@ -190,7 +190,7 @@ nv.models.discreteBar = function() {
                 })
                 .select('rect')
                 .attr('height', function(d,i) {
-                    return  Math.max(Math.abs(y(getY(d,i)) - y((yDomain && yDomain[0]) || 0)) || 1)
+                    return  Math.max(Math.abs(y(getY(d,i)) - y(0)), 1)
                 });
 
 


### PR DESCRIPTION
Fixed bug where, when yDomain[0] is negative, bars are too tall (since the subtraction is based on y(yDomain[0]) instead of y(0)).