### PR TITLE
Different colors for leaves of the same parent.

### DIFF
--- a/src/models/sunburst.js
+++ b/src/models/sunburst.js
@@ -79,7 +79,7 @@ nv.models.sunburst = function() {
                 .append("path")
                 .attr("d", arc)
                 .style("fill", function (d) {
-                    return color((d.children ? d : d.parent).name);
+                    return color(d.name);
                 })
                 .style("stroke", "#FFF")
                 .on("click", function(d) {


### PR DESCRIPTION
I need different colors for the leaves of the same parent in a sunburst diagram, the only way to accomplish this, afaik, is to change the fill-call in the sunburst model.

Unfortunately the current behaviour, coloring all leaves of a parent with the parents color is broken that way. For me it's fine. But I guess others might have a different opinion for that matter.
