### PR TITLE
Use tooltip formatter for interactiveGuideline instead of axisFormatter

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -379,14 +379,13 @@ nv.models.lineChart = function() {
                         allData[indexToHighlight].highlight = true;
                 }
 
-                var xValue = tooltip.headerFormatter()( chart.x()(singlePoint,pointIndex) );
                 interactiveLayer.tooltip
                     .chartContainer(that.parentNode)
                     .valueFormatter(function(d,i) {
                         return d === null ? "N/A" : yAxis.tickFormat()(d);
                     })
                     .data({
-                        value: xValue,
+                        value: chart.x()( singlePoint,pointIndex ),
                         index: pointIndex,
                         series: allData
                     })();
@@ -611,6 +610,8 @@ nv.models.lineChart = function() {
         xTickFormat: {get: function(){return xAxis.tickFormat();}, set: function(_){
             xAxis.tickFormat(_);
             x2Axis.tickFormat(_);
+            tooltip.headerFormatter(_);
+            interactiveLayer.tooltip.headerFormatter(_);
         }},
         yTickFormat: {get: function(){return yAxis.tickFormat();}, set: function(_){
             yAxis.tickFormat(_);

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -347,8 +347,8 @@ nv.models.lineChart = function() {
                         return !series.disabled;
                     })
                     .forEach(function(series,i) {
-                            var extent = brush.empty() ? x2.domain() : brush.extent();
-                            var currentValues = series.values.filter(function(d,i) {
+                        var extent = brush.empty() ? x2.domain() : brush.extent();
+                        var currentValues = series.values.filter(function(d,i) {
                             return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
                         });
 

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -378,7 +378,7 @@ nv.models.lineChart = function() {
                         allData[indexToHighlight].highlight = true;
                 }
 
-                var xValue = xAxis.tickFormat()(chart.x()(singlePoint,pointIndex));
+                var xValue = tooltip.headerFormatter()( chart.x()(singlePoint,pointIndex) );
                 interactiveLayer.tooltip
                     .chartContainer(that.parentNode)
                     .valueFormatter(function(d,i) {

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -60,6 +60,12 @@ nv.models.lineChart = function() {
     }).headerFormatter(function(d, i) {
         return xAxis.tickFormat()(d, i);
     });
+    
+    interactiveLayer.tooltip.valueFormatter(function(d, i) {
+        return yAxis.tickFormat()(d, i);
+    }).headerFormatter(function(d, i) {
+        return xAxis.tickFormat()(d, i);
+    });
 
 
     //============================================================
@@ -610,8 +616,6 @@ nv.models.lineChart = function() {
         xTickFormat: {get: function(){return xAxis.tickFormat();}, set: function(_){
             xAxis.tickFormat(_);
             x2Axis.tickFormat(_);
-            tooltip.headerFormatter(_);
-            interactiveLayer.tooltip.headerFormatter(_);
         }},
         yTickFormat: {get: function(){return yAxis.tickFormat();}, set: function(_){
             yAxis.tickFormat(_);

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -365,7 +365,7 @@ nv.models.lineChart = function() {
                             key: series.key,
                             value: pointYValue,
                             color: color(series,series.seriesIndex),
-                            data: series.values[pointIndex]
+                            data: point
                         });
                     });
                 //Highlight the tooltip entry based on which point the mouse is closest to.


### PR DESCRIPTION
There's two meaningful fixes here:
1. The interactive tooltip's header had been using the xAxis tickFormat.  Instead, use the formatter that's associated with the tooltip.  It's a no-op for folks who have not custom-set the tooltip headerFormat.

2. While auditing to find that fix, I noticed that the data value being used was indexed into series and not currentValues.  currentValues is a filtered copy of series, so there's a subtle bug.
 