### PR TITLE
Performance improvements for lineChart

### DIFF
--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -701,6 +701,11 @@ as well as used to print out examples using those example inputs.
             default: true,
             examples: [false]
         },
+        interactiveUpdateDelay: {
+            desc: "Advanced option.  This is the delay in milliseconds before updating the interactive elements in a chart.  If set to 0, the interactive components are synchronously updated during the chart's update cycle.  If set to a larger value, then a timeout is created and the interactive elements are updated asynchronously. There is a mild performance advantage to using 0, while the default of 300 is intended to allow smoother animations.",
+            default: 300,
+            examples: [0,300]
+        },
         staggerLabels: {
             desc: "Makes the X labels stagger at different distances from the axis so they're less likely to overlap.",
             default: false,

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -222,27 +222,6 @@ nv.models.lineChart = function() {
             var linesWrap = g.select('.nv-linesWrap')
                 .datum(data.filter(function(d) { return !d.disabled; }));
 
-            linesWrap.call(lines);
-            
-            lines2
-                .defined(lines.defined())
-                .width(availableWidth)
-                .height(availableHeight2)
-                .color(data.map(function(d,i) {
-                    return d.color || color(d, i);
-                }).filter(function(d,i) { return !data[i].disabled; }));
-
-            g.select('.nv-context')
-                .attr('transform', 'translate(0,' + ( availableHeight1 + margin.bottom + margin2.top) + ')')
-                .style('display', focusEnable ? 'initial' : 'none')
-            ;
-
-            var contextLinesWrap = g.select('.nv-context .nv-linesWrap')
-                .datum(data.filter(function(d) { return !d.disabled; }))
-                ;
-                
-            d3.transition(contextLinesWrap).call(lines2);
-
 
             // Setup Main (Focus) Axes
             if (showXAxis) {
@@ -262,70 +241,98 @@ nv.models.lineChart = function() {
             g.select('.nv-focus .nv-x.nv-axis')
                 .attr('transform', 'translate(0,' + availableHeight1 + ')');
 
-            // Setup Brush
-            brush
-                .x(x2)
-                .on('brush', function() {
-                    onBrush();
-                });
 
-            if (brushExtent) brush.extent(brushExtent);
-
-            var brushBG = g.select('.nv-brushBackground').selectAll('g')
-                .data([brushExtent || brush.extent()]);
+            if( !focusEnable )
+            {
+                linesWrap.call(lines);
+            }
+            else
+            {
+                lines2
+                    .defined(lines.defined())
+                    .width(availableWidth)
+                    .height(availableHeight2)
+                    .color(data.map(function(d,i) {
+                        return d.color || color(d, i);
+                    }).filter(function(d,i) { return !data[i].disabled; }));
     
-            var brushBGenter = brushBG.enter()
-                .append('g');
-
-            brushBGenter.append('rect')
-                .attr('class', 'left')
-                .attr('x', 0)
-                .attr('y', 0)
-                .attr('height', availableHeight2);
-
-            brushBGenter.append('rect')
-                .attr('class', 'right')
-                .attr('x', 0)
-                .attr('y', 0)
-                .attr('height', availableHeight2);
-
-            var gBrush = g.select('.nv-x.nv-brush')
-                .call(brush);
-            gBrush.selectAll('rect')
-                .attr('height', availableHeight2);
-            gBrush.selectAll('.resize').append('path').attr('d', resizePath);
-
-            onBrush();
-
-            g.select('.nv-context .nv-background rect')
-                .attr('width', availableWidth)
-                .attr('height', availableHeight2);
-
-            // Setup Secondary (Context) Axes
-            if (focusShowAxisX) {
-              x2Axis
-                  .scale(x2)
-                  ._ticks( nv.utils.calcTicksX(availableWidth/100, data) )
-                  .tickSize(-availableHeight2, 0);
-  
-              g.select('.nv-context .nv-x.nv-axis')
-                  .attr('transform', 'translate(0,' + y2.range()[0] + ')');
-              d3.transition(g.select('.nv-context .nv-x.nv-axis'))
-                  .call(x2Axis);
-            }
-
-            if (focusShowAxisY) {
-              y2Axis
-                  .scale(y2)
-                  ._ticks( nv.utils.calcTicksY(availableHeight2/36, data) )
-                  .tickSize( -availableWidth, 0);
-  
-              d3.transition(g.select('.nv-context .nv-y.nv-axis'))
-                  .call(y2Axis);
-            }
+                g.select('.nv-context')
+                    .attr('transform', 'translate(0,' + ( availableHeight1 + margin.bottom + margin2.top) + ')')
+                    .style('display', focusEnable ? 'initial' : 'none')
+                ;
+    
+                var contextLinesWrap = g.select('.nv-context .nv-linesWrap')
+                    .datum(data.filter(function(d) { return !d.disabled; }))
+                    ;
+                    
+                d3.transition(contextLinesWrap).call(lines2);
+                
             
-            g.select('.nv-context .nv-x.nv-axis')
-                .attr('transform', 'translate(0,' + y2.range()[0] + ')');
+                // Setup Brush
+                brush
+                    .x(x2)
+                    .on('brush', function() {
+                        onBrush();
+                    });
+    
+                if (brushExtent) brush.extent(brushExtent);
+    
+                var brushBG = g.select('.nv-brushBackground').selectAll('g')
+                    .data([brushExtent || brush.extent()]);
+        
+                var brushBGenter = brushBG.enter()
+                    .append('g');
+    
+                brushBGenter.append('rect')
+                    .attr('class', 'left')
+                    .attr('x', 0)
+                    .attr('y', 0)
+                    .attr('height', availableHeight2);
+    
+                brushBGenter.append('rect')
+                    .attr('class', 'right')
+                    .attr('x', 0)
+                    .attr('y', 0)
+                    .attr('height', availableHeight2);
+    
+                var gBrush = g.select('.nv-x.nv-brush')
+                    .call(brush);
+                gBrush.selectAll('rect')
+                    .attr('height', availableHeight2);
+                gBrush.selectAll('.resize').append('path').attr('d', resizePath);
+    
+                onBrush();
+    
+                g.select('.nv-context .nv-background rect')
+                    .attr('width', availableWidth)
+                    .attr('height', availableHeight2);
+    
+                // Setup Secondary (Context) Axes
+                if (focusShowAxisX) {
+                  x2Axis
+                      .scale(x2)
+                      ._ticks( nv.utils.calcTicksX(availableWidth/100, data) )
+                      .tickSize(-availableHeight2, 0);
+      
+                  g.select('.nv-context .nv-x.nv-axis')
+                      .attr('transform', 'translate(0,' + y2.range()[0] + ')');
+                  d3.transition(g.select('.nv-context .nv-x.nv-axis'))
+                      .call(x2Axis);
+                }
+    
+                if (focusShowAxisY) {
+                  y2Axis
+                      .scale(y2)
+                      ._ticks( nv.utils.calcTicksY(availableHeight2/36, data) )
+                      .tickSize( -availableWidth, 0);
+      
+                  d3.transition(g.select('.nv-context .nv-y.nv-axis'))
+                      .call(y2Axis);
+                }
+                
+                g.select('.nv-context .nv-x.nv-axis')
+                    .attr('transform', 'translate(0,' + y2.range()[0] + ')');
+            }
 
             //============================================================
             // Event Handling/Dispatching (in chart's scope)
@@ -347,7 +354,7 @@ nv.models.lineChart = function() {
                         return !series.disabled;
                     })
                     .forEach(function(series,i) {
-                        var extent = brush.empty() ? x2.domain() : brush.extent();
+                        var extent = focusEnable ? (brush.empty() ? x2.domain() : brush.extent()) : x.domain();
                         var currentValues = series.values.filter(function(d,i) {
                             return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
                         });

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -101,8 +101,7 @@ nv.models.lineChart = function() {
         if (focusShowAxisX) renderWatch.models(x2Axis);
         if (focusShowAxisY) renderWatch.models(y2Axis);
         selection.each(function(data) {
-            var container = d3.select(this),
-                that = this;
+            var container = d3.select(this);
             nv.utils.initSVG(container);
             var availableWidth = nv.utils.availableWidth(width, container, margin),
                 availableHeight1 = nv.utils.availableHeight(height, container, margin) - (focusEnable ? focusHeight : 0),
@@ -380,7 +379,7 @@ nv.models.lineChart = function() {
                 }
 
                 interactiveLayer.tooltip
-                    .chartContainer(that.parentNode)
+                    .chartContainer(chart.container.parentNode)
                     .valueFormatter(function(d,i) {
                         return d === null ? "N/A" : yAxis.tickFormat()(d);
                     })

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -159,14 +159,14 @@ nv.models.lineChart = function() {
             gEnter.append('g').attr('class', 'nv-legendWrap');
 
             var focusEnter = gEnter.append('g').attr('class', 'nv-focus');
-            focusEnter.append('g').attr('class', 'nv-background');
+            focusEnter.append('g').attr('class', 'nv-background').append('rect');
             focusEnter.append('g').attr('class', 'nv-x nv-axis');
             focusEnter.append('g').attr('class', 'nv-y nv-axis');
             focusEnter.append('g').attr('class', 'nv-linesWrap');
             focusEnter.append('g').attr('class', 'nv-interactive');
 
             var contextEnter = gEnter.append('g').attr('class', 'nv-context');
-            contextEnter.append('g').attr('class', 'nv-background');
+            contextEnter.append('g').attr('class', 'nv-background').append('rect');
             contextEnter.append('g').attr('class', 'nv-x nv-axis');
             contextEnter.append('g').attr('class', 'nv-y nv-axis');
             contextEnter.append('g').attr('class', 'nv-linesWrap');
@@ -207,9 +207,6 @@ nv.models.lineChart = function() {
                     .xScale(x);
                 wrap.select(".nv-interactive").call(interactiveLayer);
             }
-
-            focusEnter.select('.nv-background')
-                .append('rect');
 
             g.select('.nv-focus .nv-background rect')
                 .attr('width', availableWidth)
@@ -300,9 +297,6 @@ nv.models.lineChart = function() {
             gBrush.selectAll('.resize').append('path').attr('d', resizePath);
 
             onBrush();
-
-            g.select('.nv-context .nv-background')
-                .append('rect');
 
             g.select('.nv-context .nv-background rect')
                 .attr('width', availableWidth)

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -425,7 +425,9 @@ nv.models.scatter = function() {
                 timeoutID = setTimeout(updateInteractiveLayer, interactiveUpdateDelay );
             }
             else
+            {
                 updateInteractiveLayer();
+            }
 
             //store old scales for use in transitions on update
             x0 = x.copy();

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -40,6 +40,7 @@ nv.models.scatter = function() {
         , dispatch     = d3.dispatch('elementClick', 'elementDblClick', 'elementMouseover', 'elementMouseout', 'renderEnd')
         , useVoronoi   = true
         , duration     = 250
+        , interactiveUpdateDelay = 300
         ;
 
 
@@ -418,9 +419,13 @@ nv.models.scatter = function() {
             );
 
             // Delay updating the invisible interactive layer for smoother animation
-            clearTimeout(timeoutID); // stop repeat calls to updateInteractiveLayer
-            timeoutID = setTimeout(updateInteractiveLayer, 300);
-            //updateInteractiveLayer();
+            if( interactiveUpdateDelay )
+            {
+                clearTimeout(timeoutID); // stop repeat calls to updateInteractiveLayer
+                timeoutID = setTimeout(updateInteractiveLayer, interactiveUpdateDelay );
+            }
+            else
+                updateInteractiveLayer();
 
             //store old scales for use in transitions on update
             x0 = x.copy();
@@ -491,6 +496,7 @@ nv.models.scatter = function() {
         clipRadius:   {get: function(){return clipRadius;}, set: function(_){clipRadius=_;}},
         showVoronoi:   {get: function(){return showVoronoi;}, set: function(_){showVoronoi=_;}},
         id:           {get: function(){return id;}, set: function(_){id=_;}},
+        interactiveUpdateDelay: {get:function(){return interactiveUpdateDelay;}, set: function(_){interactiveUpdateDelay=_;}},
 
 
         // simple functor options


### PR DESCRIPTION
When lineChart was unified with lineWithFocusChart, a bug crept in cause the main chart to be called twice (once during the standard update, again during the onBrush() update).  This patch makes those two updates to the main chart mutually exclusive, based on the focusEnable flag.

The majority of the diff is whitespace, now that the focusChart logic is wrapped by an if.  

A few other changes are along for the ride:
* The background rects are now added with the rest of the skeleton code instead of (confusingly) later in the code.

* Avoid creating a local variable called 'that' on general principal.  It was only used in one place.

* The scatter model now offers an option for the interactiveUpdate duration - it had been hard coded to 300ms.  On my machine, that deferred update was taking 8ms to set up while a direct update was completed in under a millisecond. Library users can now choose to accept a degraded animation in favor of faster raw chart updates.  Note: I wasn't able to visually spot a difference from running at the default 300ms, so perhaps it's safe to set the default on that to 0?