### PR TITLE
Add defined to stacked area chart

### DIFF
--- a/src/models/stackedArea.js
+++ b/src/models/stackedArea.js
@@ -14,6 +14,7 @@ nv.models.stackedArea = function() {
         , container = null
         , getX = function(d) { return d.x } // accessor to get the x value from a data point
         , getY = function(d) { return d.y } // accessor to get the y value from a data point
+        , defined = function(d,i) { return !isNaN(getY(d,i)) && getY(d,i) !== null } // allows a line to be not continuous when it is not defined
         , style = 'stack'
         , offset = 'zero'
         , order = 'default'
@@ -134,6 +135,7 @@ nv.models.stackedArea = function() {
             g.attr('clip-path', clipEdge ? 'url(#nv-edge-clip-' + id + ')' : '');
 
             var area = d3.svg.area()
+                .defined(defined)
                 .x(function(d,i)  { return x(getX(d,i)) })
                 .y0(function(d) {
                     return y(d.display.y0)
@@ -144,6 +146,7 @@ nv.models.stackedArea = function() {
                 .interpolate(interpolate);
 
             var zeroArea = d3.svg.area()
+                .defined(defined)
                 .x(function(d,i)  { return x(getX(d,i)) })
                 .y0(function(d) { return y(d.display.y0) })
                 .y1(function(d) { return y(d.display.y0) });
@@ -269,6 +272,7 @@ nv.models.stackedArea = function() {
         // simple options, just get/set the necessary values
         width:      {get: function(){return width;}, set: function(_){width=_;}},
         height:     {get: function(){return height;}, set: function(_){height=_;}},
+        defined: {get: function(){return defined;}, set: function(_){defined=_;}},
         clipEdge: {get: function(){return clipEdge;}, set: function(_){clipEdge=_;}},
         offset:      {get: function(){return offset;}, set: function(_){offset=_;}},
         order:    {get: function(){return order;}, set: function(_){order=_;}},


### PR DESCRIPTION
I don't know why *defined()* exist in line chart but not in stacked area chart but I needed it. So here comes this PR where I added it.
I tested it on several stacked area chart and it works fine.