### PR TITLE
Fix Travis CI then Fix Bugs and Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ before_install:
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
 #   Meteor Tinytest support
-    - "curl https://install.meteor.com | /bin/sh"
-    - export PATH="$HOME/.meteor:$PATH"
     - "npm install -g spacejam"
 install:
     - "npm install"
     - "bower install"
 
-script: "spacejam test-packages ./"
+script: 
+    - "npm test"
+    - "spacejam test-packages nvd3:nvd3"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
 #   Meteor Tinytest support
+    - "curl https://install.meteor.com | /bin/sh"
+    - export PATH="$HOME/.meteor:$PATH"
     - "npm install -g spacejam"
 install:
     - "npm install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ install:
 
 script: 
     - "npm test"
-    - "spacejam test-packages nvd3:nvd3"
+    - "spacejam test-packages ./"
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ only include the source files you changed!
 #### Meteor Tinytests
 * Any Meteor-specific features can be tested from the command line using `tinytest` and [Spacejam](https://www.npmjs.com/package/spacejam)
 * `spacejam` can be installed by running `npm install -g spacejam`.
-* Tinytests can then be executed by running `spacejam test-packages nvd3:nvd3`.
+* Tinytests can then be executed by running `spacejam test-packages ./` from this project's root.
 
 ---
 

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -243,17 +243,23 @@ nv.models.lineChart = function() {
             // Update Axes
             //============================================================
             function updateXAxis() {
-              g.select('.nv-focus .nv-x.nv-axis')
-                .transition()
-                .duration(duration)
-                .call(xAxis);
+              if(showXAxis) {
+                g.select('.nv-focus .nv-x.nv-axis')
+                  .transition()
+                  .duration(duration)
+                  .call(xAxis)
+                ;
+              }
             }
 
             function updateYAxis() {
+              if(showYAxis) {
                 g.select('.nv-focus .nv-y.nv-axis')
-                    .transition()
-                    .duration(duration)
-                    .call(yAxis);
+                  .transition()
+                  .duration(duration)
+                  .call(yAxis)
+                ;
+              }
             }
             
             g.select('.nv-focus .nv-x.nv-axis')
@@ -531,15 +537,8 @@ nv.models.lineChart = function() {
     
     
                 // Update Main (Focus) Axes
-                if( showXAxis )
-                {
-                  updateXAxis()
-                }
-                
-                if( showYAxis )
-                {
-                  updateYAxis();
-                }
+                updateXAxis();
+                updateYAxis();
             }
 
 

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -229,6 +229,7 @@ nv.models.lineChart = function() {
                     .scale(x)
                     ._ticks(nv.utils.calcTicksX(availableWidth/100, data) )
                     .tickSize(-availableHeight1, 0);
+
             }
 
             if (showYAxis) {
@@ -237,14 +238,32 @@ nv.models.lineChart = function() {
                     ._ticks( nv.utils.calcTicksY(availableHeight1/36, data) )
                     .tickSize( -availableWidth, 0);
             }
+
+            //============================================================
+            // Update Axes
+            //============================================================
+            function updateXAxis() {
+              g.select('.nv-focus .nv-x.nv-axis')
+                .transition()
+                .duration(duration)
+                .call(xAxis);
+            }
+
+            function updateYAxis() {
+                g.select('.nv-focus .nv-y.nv-axis')
+                    .transition()
+                    .duration(duration)
+                    .call(yAxis);
+            }
             
             g.select('.nv-focus .nv-x.nv-axis')
                 .attr('transform', 'translate(0,' + availableHeight1 + ')');
 
-
             if( !focusEnable )
             {
                 linesWrap.call(lines);
+                updateXAxis();
+                updateYAxis();
             }
             else
             {
@@ -514,18 +533,12 @@ nv.models.lineChart = function() {
                 // Update Main (Focus) Axes
                 if( showXAxis )
                 {
-                  g.select('.nv-focus .nv-x.nv-axis')
-                    .transition()
-                    .duration(duration)
-                    .call(xAxis);
+                  updateXAxis()
                 }
                 
                 if( showYAxis )
                 {
-                  g.select('.nv-focus .nv-y.nv-axis')
-                    .transition()
-                    .duration(duration)
-                    .call(yAxis);
+                  updateYAxis();
                 }
             }
 
@@ -535,6 +548,7 @@ nv.models.lineChart = function() {
         renderWatch.renderEnd('lineChart immediate');
         return chart;
     }
+
 
     //============================================================
     // Event Handling/Dispatching (out of chart's scope)

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -361,7 +361,9 @@ nv.models.scatter = function() {
             groups.exit()
                 .remove();
             groups
-                .attr('class', function(d,i) { return 'nv-group nv-series-' + i })
+                .attr('class', function(d,i) {
+                    return (d.classed || '') + ' nv-group nv-series-' + i;
+                })
                 .classed('hover', function(d) { return d.hover });
             groups.watchTransition(renderWatch, 'scatter: groups')
                 .style('fill', function(d,i) { return color(d, i) })

--- a/test/mocha/line.coffee
+++ b/test/mocha/line.coffee
@@ -118,5 +118,15 @@ describe 'NVD3', ->
         it 'can add custom CSS class to series', ->
             builder.updateData sampleData2
 
-            lines = builder.$ '.nv-linesWrap .nv-groups .nv-group.dashed'
-            lines.length.should.equal 1, 'dashed class exists'
+            classed = builder.$ '.nv-linesWrap .nv-groups .nv-group.dashed'
+            
+            # Since classing has been implemented at the data-level for
+            # scatter points, there will actually be 2 elements matching
+            # the above selector, one for the scatter g element,
+            # and one for the line.
+            
+            classed.length.should.equal 2, 'dashed class exists'
+
+            scatter = builder.$ '.nv-scatterWrap .nv-groups .nv-group.dashed'
+            scatter.length.should.equal 1, 'one classed element is from scatter'
+


### PR DESCRIPTION
I made a significant and terrible mistake with #1245.  In essence, I messed up the Travis CI configuration file such that *only* Meteor tests were being run as a part of this project's continuous integration.  This PR fixes my Travis mistake and attempts to clean up the resulting collateral damage.

#### Collateral Damage

Perhaps fortunately, there was only one "bug" (according to the current suite of mocha tests) introduced between #1245 and now.  It looks like #1282 introduced a bug where axes were not rendered on a line chart if `focusEnabled` was set to `false`.  There is a patch in `lineChart.js` in this PR to fix that.

On a lesser note, #1290 changed how series are classed in a scatter model which, in effect, doubles the number of `<g>` elements that receive a class from a data parameter in a line chart.  For instance

```
var data = [
  {
    key: 'series1',
    classed: 'foo',
    values: [...]
  },
  ...
];
```

would result in a line chart with two `<g>` elements classed as `foo`, one group belongs to the `.nv-scatterWrap` and one represents the actual line in the chart.  I modified the existing test case in `line.coffee` to check for two classed elements and to confirm that one was indeed part of the scatter.

Moving forward, it might be desirable to wrap the lines and `.nv-scatterWrap` in separate divs such that some query selector could reasonably distinguish between the two.  Nevertheless, for now, I wanted to get this PR in the pipeline as soon as possible considering that the mistakes that I made in #1245 are so significant to the testing workflow of the project.