### PR TITLE
issue #1301 disable tooltip for specific series

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -529,7 +529,8 @@ nv.models.lineChart = function() {
                                 classed: d.classed,
                                 values: d.values.filter(function(d,i) {
                                     return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
-                                })
+                                }),
+                                disableTooltip: d.disableTooltip
                             };
                         })
                 );
@@ -554,7 +555,9 @@ nv.models.lineChart = function() {
     //------------------------------------------------------------
 
     lines.dispatch.on('elementMouseover.tooltip', function(evt) {
-        tooltip.data(evt).hidden(false);
+        if(!evt.series.disableTooltip){
+            tooltip.data(evt).hidden(false);
+        }
     });
 
     lines.dispatch.on('elementMouseout.tooltip', function(evt) {

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -388,7 +388,7 @@ nv.models.lineChart = function() {
                         var point = currentValues[pointIndex];
                         var pointYValue = chart.y()(point, pointIndex);
                         if (pointYValue !== null) {
-                            lines.highlightPoint(i, pointIndex, true);
+                            lines.highlightPoint(series.seriesIndex, pointIndex, true);
                         }
                         if (point === undefined) return;
                         if (singlePoint === undefined) singlePoint = point;

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -376,7 +376,7 @@ nv.models.lineChart = function() {
                 data
                     .filter(function(series, i) {
                         series.seriesIndex = i;
-                        return !series.disabled;
+                        return !series.disabled && !series.disableTooltip;
                     })
                     .forEach(function(series,i) {
                         var extent = focusEnable ? (brush.empty() ? x2.domain() : brush.extent()) : x.domain();


### PR DESCRIPTION
typical graph object was of type 

```{key: "some Key",
area: true,
values: [valuesWentHere]}```

I've added a property ```disableTooltip``` to allow for the dispatch event for tooltips to see if tooltips are enabled for that specific series