### PR TITLE
Allow an arbitrary number of ranges and sort labels accordingly to their values in BulletChart

### DIFF
--- a/src/models/bullet.js
+++ b/src/models/bullet.js
@@ -30,10 +30,11 @@ nv.models.bullet = function() {
         ;
 
     function sortLabels(labels, values){
+        var lz = labels.slice();
         labels.sort(function(a, b){
-            var iA = labels.indexOf(a);
-            var iB = labels.indexOf(b);
-            return values[iA] < values[iB];
+            var iA = lz.indexOf(a);
+            var iB = lz.indexOf(b);
+            return d3.descending(values[iA], values[iB]);
         });
     };
 
@@ -45,9 +46,9 @@ nv.models.bullet = function() {
             container = d3.select(this);
             nv.utils.initSVG(container);
 
-            var rangez = ranges.call(this, d, i).slice().sort(d3.descending),
-                markerz = markers.call(this, d, i).slice().sort(d3.descending),
-                measurez = measures.call(this, d, i).slice().sort(d3.descending),
+            var rangez = ranges.call(this, d, i).slice(),
+                markerz = markers.call(this, d, i).slice(),
+                measurez = measures.call(this, d, i).slice(),
                 rangeLabelz = rangeLabels.call(this, d, i).slice(),
                 markerLabelz = markerLabels.call(this, d, i).slice(),
                 measureLabelz = measureLabels.call(this, d, i).slice();
@@ -56,6 +57,11 @@ nv.models.bullet = function() {
             sortLabels(rangeLabelz, rangez);
             sortLabels(markerLabelz, markerz);
             sortLabels(measureLabelz, measurez);
+
+            // sort values descending
+            rangez.sort(d3.descending);
+            markerz.sort(d3.descending);
+            measurez.sort(d3.descending);
 
             // Setup Scales
             // Compute the new x-scale.

--- a/src/models/bullet.js
+++ b/src/models/bullet.js
@@ -26,7 +26,16 @@ nv.models.bullet = function() {
         , tickFormat = null
         , color = nv.utils.getColor(['#1f77b4'])
         , dispatch = d3.dispatch('elementMouseover', 'elementMouseout', 'elementMousemove')
+        , defaultRangeLabels = ["Maximum", "Mean", "Minimum"]
         ;
+
+    function sortLabels(labels, values){
+        labels.sort(function(a, b){
+            var iA = labels.indexOf(a);
+            var iB = labels.indexOf(b);
+            return values[iA] < values[iB];
+        });
+    };
 
     function chart(selection) {
         selection.each(function(d, i) {
@@ -42,6 +51,11 @@ nv.models.bullet = function() {
                 rangeLabelz = rangeLabels.call(this, d, i).slice(),
                 markerLabelz = markerLabels.call(this, d, i).slice(),
                 measureLabelz = measureLabels.call(this, d, i).slice();
+
+            // Sort labels according to their sorted values
+            sortLabels(rangeLabelz, rangez);
+            sortLabels(markerLabelz, markerz);
+            sortLabels(measureLabelz, measurez);
 
             // Setup Scales
             // Compute the new x-scale.
@@ -67,9 +81,10 @@ nv.models.bullet = function() {
             var gEnter = wrapEnter.append('g');
             var g = wrap.select('g');
 
-            gEnter.append('rect').attr('class', 'nv-range nv-rangeMax');
-            gEnter.append('rect').attr('class', 'nv-range nv-rangeAvg');
-            gEnter.append('rect').attr('class', 'nv-range nv-rangeMin');
+            for(var i=0,il=rangez.length; i<il; i++){
+                gEnter.append('rect').attr('class', 'nv-range nv-range'+i);
+            }
+
             gEnter.append('rect').attr('class', 'nv-measure');
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
@@ -79,25 +94,14 @@ nv.models.bullet = function() {
             var xp0 = function(d) { return d < 0 ? x0(d) : x0(0) },
                 xp1 = function(d) { return d < 0 ? x1(d) : x1(0) };
 
-            g.select('rect.nv-rangeMax')
-                .attr('height', availableHeight)
-                .attr('width', w1(rangeMax > 0 ? rangeMax : rangeMin))
-                .attr('x', xp1(rangeMax > 0 ? rangeMax : rangeMin))
-                .datum(rangeMax > 0 ? rangeMax : rangeMin)
-
-            g.select('rect.nv-rangeAvg')
-                .attr('height', availableHeight)
-                .attr('width', w1(rangeAvg))
-                .attr('x', xp1(rangeAvg))
-                .datum(rangeAvg)
-
-            g.select('rect.nv-rangeMin')
-                .attr('height', availableHeight)
-                .attr('width', w1(rangeMax))
-                .attr('x', xp1(rangeMax))
-                .attr('width', w1(rangeMax > 0 ? rangeMin : rangeMax))
-                .attr('x', xp1(rangeMax > 0 ? rangeMin : rangeMax))
-                .datum(rangeMax > 0 ? rangeMin : rangeMax)
+            for(var i=0,il=rangez.length; i<il; i++){
+                var range = rangez[i];
+                g.select('rect.nv-range'+i)
+                    .attr('height', availableHeight)
+                    .attr('width', w1(range))
+                    .attr('x', xp1(range))
+                    .datum(range)
+            }
 
             g.select('rect.nv-measure')
                 .style('fill', color)
@@ -168,7 +172,7 @@ nv.models.bullet = function() {
 
             wrap.selectAll('.nv-range')
                 .on('mouseover', function(d,i) {
-                    var label = rangeLabelz[i] || (!i ? "Maximum" : i == 1 ? "Mean" : "Minimum");
+                    var label = rangeLabelz[i] || defaultRangeLabels[i];
                     dispatch.elementMouseover({
                         value: d,
                         label: label,
@@ -183,7 +187,7 @@ nv.models.bullet = function() {
                     })
                 })
                 .on('mouseout', function(d,i) {
-                    var label = rangeLabelz[i] || (!i ? "Maximum" : i == 1 ? "Mean" : "Minimum");
+                    var label = rangeLabelz[i] || defaultRangeLabels[i];
                     dispatch.elementMouseout({
                         value: d,
                         label: label,

--- a/src/models/bullet.js
+++ b/src/models/bullet.js
@@ -27,6 +27,7 @@ nv.models.bullet = function() {
         , color = nv.utils.getColor(['#1f77b4'])
         , dispatch = d3.dispatch('elementMouseover', 'elementMouseout', 'elementMousemove')
         , defaultRangeLabels = ["Maximum", "Mean", "Minimum"]
+        , legacyRangeClassNames = ["Max", "Avg", "Min"]
         ;
 
     function sortLabels(labels, values){
@@ -88,7 +89,7 @@ nv.models.bullet = function() {
             var g = wrap.select('g');
 
             for(var i=0,il=rangez.length; i<il; i++){
-                gEnter.append('rect').attr('class', 'nv-range nv-range'+i);
+                gEnter.append('rect').attr('class', 'nv-range nv-range'+i+' nv-range'+legacyRangeClassNames[i]);
             }
 
             gEnter.append('rect').attr('class', 'nv-measure');

--- a/src/models/bullet.js
+++ b/src/models/bullet.js
@@ -89,7 +89,11 @@ nv.models.bullet = function() {
             var g = wrap.select('g');
 
             for(var i=0,il=rangez.length; i<il; i++){
-                gEnter.append('rect').attr('class', 'nv-range nv-range'+i+' nv-range'+legacyRangeClassNames[i]);
+                var rangeClassNames = 'nv-range nv-range'+i;
+                if(i <= 2){
+                    rangeClassNames = rangeClassNames + ' nv-range'+legacyRangeClassNames[i];
+                }
+                gEnter.append('rect').attr('class', rangeClassNames);
             }
 
             gEnter.append('rect').attr('class', 'nv-measure');

--- a/test/mocha/bullet.coffee
+++ b/test/mocha/bullet.coffee
@@ -53,9 +53,9 @@ describe 'NVD3', ->
           cssClasses = [
               '.nv-bulletWrap'
               '.nv-bullet'
-              '.nv-range0'
-              '.nv-range1'
-              '.nv-range2'
+              '.nv-rangeMax'
+              '.nv-rangeAvg'
+              '.nv-rangeMin'
               '.nv-measure'
               '.nv-markerTriangle'
               '.nv-titles'
@@ -154,7 +154,7 @@ describe 'NVD3', ->
                 left: 0
               width: 300
             builder.build options, sampleData
-            parseInt( builder.$(".nv-range2")[0].getAttribute('width') ).should.be.equal 300
+            parseInt( builder.$(".nv-rangeMax")[0].getAttribute('width') ).should.be.equal 300
 
           it 'height', ->
             options =
@@ -165,5 +165,5 @@ describe 'NVD3', ->
                 left: 0
               height: 300
             builder.build options, sampleData
-            parseInt( builder.$(".nv-range2")[0].getAttribute('height') ).should.be.equal 300
+            parseInt( builder.$(".nv-rangeMax")[0].getAttribute('height') ).should.be.equal 300
 

--- a/test/mocha/bullet.coffee
+++ b/test/mocha/bullet.coffee
@@ -53,9 +53,9 @@ describe 'NVD3', ->
           cssClasses = [
               '.nv-bulletWrap'
               '.nv-bullet'
-              '.nv-rangeMax'
-              '.nv-rangeAvg'
-              '.nv-rangeMin'
+              '.nv-range0'
+              '.nv-range1'
+              '.nv-range2'
               '.nv-measure'
               '.nv-markerTriangle'
               '.nv-titles'
@@ -124,7 +124,7 @@ describe 'NVD3', ->
           it 'clears chart objects for no data', ->
             builder = new ChartBuilder nv.models.bulletChart()
             builder.buildover options, sampleData, []
-            
+
             groups = builder.$ 'g'
             groups.length.should.equal 0, 'removes chart components'
 
@@ -154,7 +154,7 @@ describe 'NVD3', ->
                 left: 0
               width: 300
             builder.build options, sampleData
-            parseInt( builder.$(".nv-rangeMax")[0].getAttribute('width') ).should.be.equal 300
+            parseInt( builder.$(".nv-range2")[0].getAttribute('width') ).should.be.equal 300
 
           it 'height', ->
             options =
@@ -165,5 +165,5 @@ describe 'NVD3', ->
                 left: 0
               height: 300
             builder.build options, sampleData
-            parseInt( builder.$(".nv-rangeMax")[0].getAttribute('height') ).should.be.equal 300
+            parseInt( builder.$(".nv-range2")[0].getAttribute('height') ).should.be.equal 300
 


### PR DESCRIPTION
Currently it's only possible to define three ranges (min, mean, max). It might be quite usefull to define an arbitrary number of ranges.

Also, the existing code sorts the values in descending order,  but leaves the label Arrays untouched. This might cause some confusion when the values are not already provided in the right order.

This pull requests allows to define an arbitrary number of ranges and keeps the labels in the right order. If no range labels are provided, the code falls back to the previous defaults (Minimum, Mean, Maximum).