### PR TITLE
Expose lineChart's state

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -579,7 +579,7 @@ nv.models.lineChart = function() {
     chart.y2Axis = y2Axis;
     chart.interactiveLayer = interactiveLayer;
     chart.tooltip = tooltip;
-
+    chart.state = state;
     chart.dispatch = dispatch;
     chart.options = nv.utils.optionsFunc.bind(chart);
 


### PR DESCRIPTION
I had to modify lineChart's state manually and couldn't access it, though I could access state of other chart models. I looked up the sources and found that instead of exposing lineChart's state there's just blank line.