### PR TITLE
Fixed turning off staggerLabels after they have been previously turned on

### DIFF
--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -131,6 +131,15 @@ nv.models.axis = function() {
                         xTicks
                             .attr('transform', rotateLabelsRule)
                             .style('text-anchor', rotateLabels%360 > 0 ? 'start' : 'end');
+                    } else {
+                        if (staggerLabels) {
+                            xTicks
+                                .attr('transform', function(d,i) {
+                                    return 'translate(0,' + (i % 2 == 0 ? '0' : '12') + ')'
+                                });
+                        } else {
+                            xTicks.attr('transform', "translate(0,0)");
+                        }
                     }
                     axisLabel.enter().append('text').attr('class', 'nv-axislabel');
                     w = 0;
@@ -171,14 +180,6 @@ nv.models.axis = function() {
                             .attr('transform', function(d,i) {
                                 return 'translate(' + nv.utils.NaNtoZero((scale(d) + (isOrdinal ? scale.rangeBand() / 2 : 0))) + ',0)'
                             });
-                    }
-                    if (staggerLabels) {
-                        xTicks
-                            .attr('transform', function(d,i) {
-                                return 'translate(0,' + (i % 2 == 0 ? '0' : '12') + ')'
-                            });
-                    } else {
-                        xTicks.attr('transform', "translate(0,0)");
                     }
 
                     break;

--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -172,11 +172,14 @@ nv.models.axis = function() {
                                 return 'translate(' + nv.utils.NaNtoZero((scale(d) + (isOrdinal ? scale.rangeBand() / 2 : 0))) + ',0)'
                             });
                     }
-                    if (staggerLabels)
+                    if (staggerLabels) {
                         xTicks
                             .attr('transform', function(d,i) {
                                 return 'translate(0,' + (i % 2 == 0 ? '0' : '12') + ')'
                             });
+                    } else {
+                        xTicks.attr('transform', "translate(0,0)");
+                    }
 
                     break;
                 case 'right':


### PR DESCRIPTION
If you set staggerLabels to true and decide to change it to false later, chart won't update the labels and they remain staggered forever.

This should close issue https://github.com/novus/nvd3/issues/80