### PR TITLE
Optimise scatter model

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -374,6 +374,7 @@ nv.models.scatter = function() {
                 .attr('class', function(d,i) {
                     return (d.classed || '') + ' nv-group nv-series-' + i;
                 })
+                .classed('nv-noninteractive', !interactive)
                 .classed('hover', function(d) { return d.hover });
             groups.watchTransition(renderWatch, 'scatter: groups')
                 .style('fill', function(d,i) { return color(d, i) })
@@ -414,7 +415,6 @@ nv.models.scatter = function() {
                 d3.select(this)
                     .classed('nv-point', true)
                     .classed('nv-point-' + d[1], true)
-                    .classed('nv-noninteractive', !interactive)
                 ;
             });
             points

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -415,7 +415,6 @@ nv.models.scatter = function() {
                     .classed('nv-point', true)
                     .classed('nv-point-' + d[1], true)
                     .classed('nv-noninteractive', !interactive)
-                    .classed('hover',false)
                 ;
             });
             points

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -53,7 +53,33 @@ nv.models.scatter = function() {
         , needsUpdate = false // Flag for when the points are visually updating, but the interactive layer is behind, to disable tooltips
         , renderWatch = nv.utils.renderWatch(dispatch, duration)
         , _sizeRange_def = [16, 256]
+        , _caches
         ;
+
+    function getCache(d) {
+        var cache, i;
+        cache = _caches = _caches || {};
+        i = d[0].series;
+        cache = cache[i] = cache[i] || {};
+        i = d[1];
+        cache = cache[i] = cache[i] || {};
+        return cache;
+    }
+
+    function getDiffs(d) {
+        var i, key,
+            point = d[0],
+            cache = getCache(d),
+            diffs = false;
+        for (i = 1; i < arguments.length; i ++) {
+            key = arguments[i];
+            if (cache[key] !== point[key] || !cache.hasOwnProperty(key)) {
+                cache[key] = point[key];
+                diffs = true;
+            }
+        }
+        return diffs;
+    }
 
     function chart(selection) {
         renderWatch.reset();

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -394,6 +394,9 @@ nv.models.scatter = function() {
                             })
                     });
             points.enter().append('path')
+                .attr('class', function (d) {
+                    return 'nv-point nv-point-' + d[1];
+                })
                 .style('fill', function (d) { return d.color })
                 .style('stroke', function (d) { return d.color })
                 .attr('transform', function(d) {
@@ -411,12 +414,6 @@ nv.models.scatter = function() {
                     return 'translate(' + nv.utils.NaNtoZero(x(getX(d[0],d[1]))) + ',' + nv.utils.NaNtoZero(y(getY(d[0],d[1]))) + ')'
                 })
                 .remove();
-            points.each(function(d) {
-                d3.select(this)
-                    .classed('nv-point', true)
-                    .classed('nv-point-' + d[1], true)
-                ;
-            });
             points
                 .watchTransition(renderWatch, 'scatter points')
                 .attr('transform', function(d) {

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -157,6 +157,8 @@ nv.models.scatter = function() {
             y0 = y0 || y;
             z0 = z0 || z;
 
+            var scaleDiff = x(1) !== x0(1) || y(1) !== y0(1) || z(1) !== z0(1);
+
             // Setup containers and skeleton of chart
             var wrap = container.selectAll('g.nv-wrap.nv-scatter').data([data]);
             var wrapEnter = wrap.enter().append('g').attr('class', 'nvd3 nv-wrap nv-scatter nv-chart-' + id);

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -442,8 +442,6 @@ nv.models.scatter = function() {
                     return 'translate(' + nv.utils.NaNtoZero(x(getX(d[0],d[1]))) + ',' + nv.utils.NaNtoZero(y(getY(d[0],d[1]))) + ')'
                 })
                 .remove();
-            points
-                .watchTransition(renderWatch, 'scatter points');
             points.filter(function (d) { return scaleDiff || getDiffs(d, 'x', 'y'); })
                 .watchTransition(renderWatch, 'scatter points')
                 .attr('transform', function(d) {

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -443,6 +443,8 @@ nv.models.scatter = function() {
                 })
                 .remove();
             points
+                .watchTransition(renderWatch, 'scatter points');
+            points.filter(function (d) { return scaleDiff || getDiffs(d, 'x', 'y'); })
                 .watchTransition(renderWatch, 'scatter points')
                 .attr('transform', function(d) {
                     //nv.log(d, getX(d[0],d[1]), x(getX(d[0],d[1])));

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -447,7 +447,9 @@ nv.models.scatter = function() {
                 .attr('transform', function(d) {
                     //nv.log(d, getX(d[0],d[1]), x(getX(d[0],d[1])));
                     return 'translate(' + nv.utils.NaNtoZero(x(getX(d[0],d[1]))) + ',' + nv.utils.NaNtoZero(y(getY(d[0],d[1]))) + ')'
-                })
+                });
+            points.filter(function (d) { return scaleDiff || getDiffs(d, 'shape', 'size'); })
+                .watchTransition(renderWatch, 'scatter points')
                 .attr('d',
                     nv.utils.symbol()
                     .type(function(d) { return getShape(d[0]); })


### PR DESCRIPTION
We've been using nvd3.js at Learning Science Ltd. for plotting continuously generated data, and found the performance of updating a chart to reduce dramatically as the total number of data points increased.

Through some profiling I attributed this to the scatter model (used by most models). The performance is proportional to the total number of nodes because of some unnecessary operations to the D3 update selection.

I have carefully removed or moved operations that do not need to be called on existing nodes and culled the remaining ones by adding some caching (e.g updating position). I've tested the affect of each where possible.

This passes the unit-tests and I have done a side by side comparison of the examples including interactivity. My performance tests show vastly reduced overhead in maintaining existing nodes on redraw.

Resizing a chart will still be fairly slow because it requires all node positions to be recalculated. The impact of this can be reduced further by setting axis range manually and setting transition durations to zero:

``` JavaScript
var chart = nv.models.lineChart();
chart.duration(0);
for (var key in chart) {
    if (typeof chart[key].duration === 'function') {
        chart[key].duration(0);
    }
}
```