### PR TITLE
Bug fix for #1263 Tooltip doesn't hide

### DIFF
--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -83,7 +83,8 @@ nv.interactiveGuideline = function() {
                 /* If mouseX/Y is outside of the chart's bounds,
                  trigger a mouseOut event.
                  */
-                if (mouseX < 0 || mouseY < 0
+                if (d3.event.type === 'mouseout'
+                    || mouseX < 0 || mouseY < 0
                     || mouseX > availableWidth || mouseY > availableHeight
                     || (d3.event.relatedTarget && d3.event.relatedTarget.ownerSVGElement === undefined)
                     || mouseOutAnyReason


### PR DESCRIPTION
Applied and tested fix as proposed by @slestang
Tested under Google Chrome 47.0.2526.73 m (64-bit) / Windows 7 (x64).
Tooltips now hide after switching browser tabs (as soon as mouse focus returns to the tab containing the chart)