### PR TITLE
pieChart.js: fixed issue with regards to width and height not being used. (Scaling issues)

### DIFF
--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -66,8 +66,8 @@ nv.models.pieChart = function() {
             nv.utils.initSVG(container);
 
             var that = this;
-            var availableWidth = nv.utils.availableWidth(width, container, margin),
-                availableHeight = nv.utils.availableHeight(height, container, margin);
+            var availableWidth = nv.utils.availableWidth(pie.width(), container, margin),
+                availableHeight = nv.utils.availableHeight(pie.height(), container, margin);
 
             chart.update = function() { container.transition().call(chart); };
             chart.container = this;


### PR DESCRIPTION
The available width and height were determined by using the width and height of the parent element. This is incorrect behaviour if the width and height are explicitly set. Width and height are inherited properties are should be accessed by referencing pie instead of use width and height directly (which would result in undefined).

Pull request fixes the issue by referencing the pie width and height instead of the pieChart width and height. 