### PR TITLE
Fix generation of lineChart

### DIFF
--- a/src/models/line.js
+++ b/src/models/line.js
@@ -154,6 +154,8 @@ nv.models.line = function() {
                     .y(function(d,i) { return nv.utils.NaNtoZero(y0(getY(d,i))) })
             );
 
+            linePaths.style('stroke', function(d,i,j){ return color(d, j)});
+
             linePaths.watchTransition(renderWatch, 'line: linePaths')
                 .attr('d',
                     d3.svg.line()


### PR DESCRIPTION
In the case of a line charts containing multiple lines, the color
of the line was white resulting in a looking non displayed graph. This
patch fixes the issue by using an approach similar to the one
used in multibarChart.