### PR TITLE
If growOnHover is set to false, do not reduce the pie chart space.

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -64,9 +64,7 @@ nv.models.pie = function() {
                     arcsRadiusOuter = arcsRadius.map(function (d) { return (d.outer - d.outer / 5) * radius; });
                     arcsRadiusInner = arcsRadius.map(function (d) { return (d.inner - d.inner / 5) * radius; });
                     donutRatio = d3.min(arcsRadius.map(function (d) { return (d.inner - d.inner / 5); }));
-                }
-                else
-                {
+                } else {
                     arcsRadiusOuter = arcsRadius.map(function (d) { return d.outer * radius; });
                     arcsRadiusInner = arcsRadius.map(function (d) { return d.inner * radius; });
                     donutRatio = d3.min(arcsRadius.map(function (d) { return d.inner; }));

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -60,9 +60,17 @@ nv.models.pie = function() {
                     arcsRadiusInner.push(inner);
                 }
             } else {
-                arcsRadiusOuter = arcsRadius.map(function (d) { return (d.outer - d.outer / 5) * radius; });
-                arcsRadiusInner = arcsRadius.map(function (d) { return (d.inner - d.inner / 5) * radius; });
-                donutRatio = d3.min(arcsRadius.map(function (d) { return (d.inner - d.inner / 5); }));
+                if(growOnHover){
+                    arcsRadiusOuter = arcsRadius.map(function (d) { return (d.outer - d.outer / 5) * radius; });
+                    arcsRadiusInner = arcsRadius.map(function (d) { return (d.inner - d.inner / 5) * radius; });
+                    donutRatio = d3.min(arcsRadius.map(function (d) { return (d.inner - d.inner / 5); }));
+                }
+                else
+                {
+                    arcsRadiusOuter = arcsRadius.map(function (d) { return d.outer * radius; });
+                    arcsRadiusInner = arcsRadius.map(function (d) { return d.inner * radius; });
+                    donutRatio = d3.min(arcsRadius.map(function (d) { return d.inner; }));
+                }
             }
             nv.utils.initSVG(container);
 


### PR DESCRIPTION
Currently, the pie chart is a little bit smaller than the available width because of the growOnHover option. If this option is set to false, do not reduce the pie size.