### PR TITLE
Fix for forceY on stackArea.scatter always getting set to [0]

### DIFF
--- a/src/models/stackedArea.js
+++ b/src/models/stackedArea.js
@@ -114,7 +114,6 @@ nv.models.stackedArea = function() {
                 .y(function(d) {
                     if (d.display !== undefined) { return d.display.y + d.display.y0; }
                 })
-                .forceY([0])
                 .color(data.map(function(d,i) {
                     d.color = d.color || color(d, d.seriesIndex);
                     return d.color;


### PR DESCRIPTION
I noticed that stackedArea.scatter.forceY can't ever be user set because it always get hard set to [0]. Since there is code to default it to [0] right above I figured this must be an error.