### PR TITLE
Change calcApproxTextWidth to return 0 if fontSize is NaN

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -183,7 +183,7 @@ nv.utils.calcApproxTextWidth = function (svgTextElem) {
     if (nv.utils.isFunction(svgTextElem.style) && nv.utils.isFunction(svgTextElem.text)) {
         var fontSize = parseInt(svgTextElem.style("font-size").replace("px",""), 10);
         var textLength = svgTextElem.text().length;
-        return textLength * fontSize * 0.5;
+        return nv.utils.NaNtoZero(textLength * fontSize * 0.5);
     }
     return 0;
 };


### PR DESCRIPTION
Not entirely sure why this happens, but we update charts in response to user selectable options, and sometimes the "font-size" style is not yet set on the relevant text element during the update, resulting in an error on the console. Don't know if this is just a band-aid over some other underlying problem, but it at least gets rid of the error.