### PR TITLE
Reset tick transform attribute before rotateLabel calculations

### DIFF
--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -116,6 +116,8 @@ nv.models.axis = function() {
                     var xTicks = g.selectAll('g').select("text");
                     var rotateLabelsRule = '';
                     if (rotateLabels%360) {
+                        //Reset transform on ticks so textHeight can be calculated correctly
+                        xTicks.attr('transform', ''); 
                         //Calculate the longest xTick width
                         xTicks.each(function(d,i){
                             var box = this.getBoundingClientRect();


### PR DESCRIPTION
A quick fix for #1475. This is the safe and simple solution of resetting the transform attribute on xTicks before doing the textHeight calculation. I didn't notice any rendering issues because the transform reset didn't have any visual impact when I stepped through with a debugger.

I also played around with an implementation that took advantage of the persistence of the transform attribute, but it seemed like it could easily regress down the road since a lot of attributes on other elements get reset on every update.