### PR TITLE
Add fontSize option for axis labels

### DIFF
--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -963,6 +963,11 @@ as well as used to print out examples using those example inputs.
             desc: "For parallel coordinate: Label displayed under the undefined values line.",
             default: 'undefined values',
             examples: ["values not defined"]
+        },
+        fontSize: {
+            desc: "Sets the font-size CSS style on axis labels.",
+            default: "undefined",
+            examples: ["12px", "1em"]
         }
     };
 </script>

--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -19,6 +19,7 @@ nv.models.axis = function() {
         , isOrdinal = false
         , ticks = null
         , axisLabelDistance = 0
+        , fontSize = undefined
         , duration = 250
         , dispatch = d3.dispatch('renderEnd')
         ;
@@ -65,6 +66,11 @@ nv.models.axis = function() {
             var axisLabel = g.selectAll('text.nv-axislabel')
                 .data([axisLabelText || null]);
             axisLabel.exit().remove();
+
+            //only skip when fontSize is undefined so it can be cleared with a null or blank string
+            if (fontSize !== undefined) {
+                g.selectAll('g').select("text").style('font-size', fontSize);
+            }
 
             var xLabelMargin;
             var axisMaxMin;
@@ -357,6 +363,7 @@ nv.models.axis = function() {
         height:            {get: function(){return height;}, set: function(_){height=_;}},
         ticks:             {get: function(){return ticks;}, set: function(_){ticks=_;}},
         width:             {get: function(){return width;}, set: function(_){width=_;}},
+        fontSize:          {get: function(){return fontSize;}, set: function(_){fontSize=_;}},
 
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){


### PR DESCRIPTION
Simple font-size override option for axis labels. I think in the future it could also allow a function override for more responsive behavior.