### PR TITLE
Nvd3/bugfixes

### DIFF
--- a/src/css/axis.css
+++ b/src/css/axis.css
@@ -28,7 +28,10 @@
     /*this selector may not be necessary*/ .nvd3 .nv-axis line.zero {
     stroke-opacity: .75;
 }
-
+.nvd3 .nv-axis .notext text,
+    /*this selector may not be necessary*/ .nvd3 .nv-axis text.notext {
+    opacity: 0;
+}
 .nvd3 .nv-axis .nv-axisMaxMin text {
     font-weight: bold;
 }

--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -53,6 +53,15 @@ nv.models.axis = function() {
             else if (axis.orient() == 'top' || axis.orient() == 'bottom')
                 axis.ticks(Math.abs(scale.range()[1] - scale.range()[0]) / 100);
 
+            //Avoid ticks overlapping (needed especially for log scale).
+            if (ticks !== null && (axis.orient() == 'left' || axis.orient() == 'right')) {
+                var currentTicks = g.selectAll('.tick').filter(function () { return this.textContent !== ""; });
+                var mod = Math.round(currentTicks[0].length / ticks);
+                currentTicks.each(function (d, i) {
+                    d3.select(this).classed('notext', function () { return (mod === 0 || i % mod === 0) ? false : true; });
+                });
+            }
+            
             //TODO: consider calculating width/height based on whether or not label is added, for reference in charts using this component
             g.watchTransition(renderWatch, 'axis').call(axis);
 

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -191,7 +191,19 @@ nv.models.lineChart = function() {
                         margin.top = legend.height();
                         availableHeight1 = nv.utils.availableHeight(height, container, margin) - (focusEnable ? focusHeight : 0);
                     }
+                
+                //Do not display the legend if there isn't enough space
+                if (availableHeight1 === 0) {
+                    g.select('.nv-legendWrap')
+                        .datum([])
+                        .call(legend);
 
+                    if (margin.top != legend.height()) {
+                        margin.top = legend.height();
+                        availableHeight1 = nv.utils.availableHeight(height, container, margin) - (focusEnable ? focusHeight : 0);
+                    }
+                }
+                
                     wrap.select('.nv-legendWrap')
                         .attr('transform', 'translate(0,' + (-margin.top) +')');
                 }


### PR DESCRIPTION
- Avoid ticks overlapping (needed especially for log scale).
- Do not display the legend if there isn't enough space (line chart)

Corresponding to [this](https://github.com/novus/nvd3/pull/1422) PR. (Merge issue)
