### PR TITLE
StackedAreaChart bugfix: Corrected wrong variable name in use.

### DIFF
--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -390,8 +390,8 @@ nv.models.stackedAreaChart = function() {
                         //To handle situation where the stacked area chart is negative, we need to use absolute values
                         //when checking if the mouse Y value is within the stack area.
                         yValue = Math.abs(yValue);
-                        var stackedY0 = Math.abs(series.stackedValue.y0);
-                        var stackedY = Math.abs(series.stackedValue.y);
+                        var stackedY0 = Math.abs(series.point.display.y0);
+                        var stackedY = Math.abs(series.point.display.y);
                         if ( yValue >= stackedY0 && yValue <= (stackedY + stackedY0))
                         {
                             indexToHighlight = i;


### PR DESCRIPTION
variable 'stackedValue' was renamed to 'point.display' but old variable name was used.