### PR TITLE
Corrected lineplusbarchart mouseover tooltip event where y1Axis and y2Axis are switched.

### DIFF
--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -70,13 +70,13 @@ nv.models.linePlusBarChart = function() {
     //------------------------------------------------------------
 
     var getBarsAxis = function() {
-        return switchYAxisOrder
+        return !switchYAxisOrder
             ? { main: y2Axis, focus: y4Axis }
             : { main: y1Axis, focus: y3Axis }
     }
 
     var getLinesAxis = function() {
-        return switchYAxisOrder
+        return !switchYAxisOrder
             ? { main: y1Axis, focus: y3Axis }
             : { main: y2Axis, focus: y4Axis }
     }


### PR DESCRIPTION
Corrected bug in lineplusbarchart where multi y-axis tickformat is getting switched with other y axis.

For Example:
Bar chart tooltip y2Axis would have y1Axis tickformat, while line tooltip
would have bar chart y1Axis tickformat.

Note that the both y1Axis and y2Axis would have the correct format, but
the tooltip mouse over for each would be SWITCHED.

Solution:
Logic error in retrieval of barchart and linechart axis during mouse over
event.