### PR TITLE
Format MultiChart's interactive tooltip's header with headerFormatter

### DIFF
--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -419,6 +419,9 @@ nv.models.multiChart = function() {
 
                     interactiveLayer.tooltip
                     .chartContainer(chart.container.parentNode)
+                    .headerFormatter(function(d, i) {
+                        return xAxis.tickFormat()(d, i);
+                    })
                     .valueFormatter(function(d,i) {
                         var yAxis = allData[i].yAxis;
                         return d === null ? "N/A" : yAxis.tickFormat()(d);


### PR DESCRIPTION
Otherwise the header has the raw data, unlike with the "old" tooltip

Steps to reproduce:
- Add `chart.useInteractiveGuideline(true);` to `examples/multiChart.html`
- Add formatting to x-axis, for example `chart.xAxis.tickFormat(d3.format(',.1f'));`

In the current `master` branch you can see different formatting on tooltip's header and x-axis. With this fix, the formatting is the same in the interactive tooltip and the x-axis.