### PR TITLE
Sparkline additional spots

### DIFF
--- a/examples/sparkline.html
+++ b/examples/sparkline.html
@@ -20,6 +20,15 @@
         #chart1 {
             height: 30px;
         }
+        .odd {
+            stroke: #801010;
+            fill: #802638;
+        }
+
+        .even {
+            stroke: #555880;
+            fill: white;
+        }
     </style>
 </head>
 <body>
@@ -30,9 +39,18 @@
 
     nv.addGraph({
         generate: function() {
+            var spots = [];
+            for (var i = 0; i < 20; ++i) {
+                spots.push({
+                    x: i * 5,
+                    y: 2 * Math.cos(i * 2),
+                    cssClass: i % 2 ? 'odd' : 'even'
+                });
+            }
             var chart = nv.models.sparkline()
                     .width(400)
                     .height(30)
+                    .spots(spots);
 
             d3.select("#chart1")
                     .datum(sine())

--- a/examples/sparkline.html
+++ b/examples/sparkline.html
@@ -33,32 +33,46 @@
 </head>
 <body>
 
-<h2>Sparkline: <svg id="chart1" class="sparkline"></svg></h2>
+<h2>Sparkline:</h2>
+<svg id="chart1" class="sparkline"></svg>
+
+<h2>Sparkline with spots:</h2>
+<svg id="chart2" class="sparkline"></svg>
 
 <script>
 
-    nv.addGraph({
-        generate: function() {
-            var spots = [];
-            for (var i = 0; i < 20; ++i) {
-                spots.push({
-                    x: i * 5,
-                    y: 2 * Math.cos(i * 2),
-                    cssClass: i % 2 ? 'odd' : 'even'
-                });
+    drawChart("#chart1");
+    drawChart("#chart2", spots());
+
+    function drawChart(chartId, spots) {
+        nv.addGraph({
+            generate: function() {
+                var chart = nv.models.sparkline()
+                        .width(400)
+                        .height(30)
+                        .spots(spots);
+
+                d3.select(chartId)
+                        .datum(sine())
+                        .call(chart);
+
+                return chart;
             }
-            var chart = nv.models.sparkline()
-                    .width(400)
-                    .height(30)
-                    .spots(spots);
+        });
 
-            d3.select("#chart1")
-                    .datum(sine())
-                    .call(chart);
+    }
 
-            return chart;
+    function spots() {
+        var spots = [];
+        for (var i = 0; i < 20; ++i) {
+            spots.push({
+                x: i * 5,
+                y: Math.cos(i * 2),
+                cssClass: i % 2 ? 'odd' : 'even'
+            });
         }
-    });
+        return spots;
+    }
 
     function sine() {
         var sin = [];

--- a/examples/sparkline.html
+++ b/examples/sparkline.html
@@ -20,12 +20,12 @@
         #chart1 {
             height: 30px;
         }
-        .odd {
+        .nvd3.nv-sparkline .nv-spot.odd {
             stroke: #801010;
             fill: #802638;
         }
 
-        .even {
+        .nvd3.nv-sparkline .nv-spot.even {
             stroke: #555880;
             fill: white;
         }

--- a/examples/sparklinePlus.html
+++ b/examples/sparklinePlus.html
@@ -23,6 +23,16 @@
             font-size: 14px;
             margin-top: -6px;
         }
+
+        .nvd3.nv-sparkline .nv-spot.red {
+            stroke: red;
+            fill: red;
+        }
+
+        .nvd3.nv-sparkline .nv-spot.blue {
+            stroke: blue;
+            fill: blue;
+        }
     </style>
 </head>
 <body class='with-3d-shadow with-transitions'>
@@ -33,16 +43,16 @@
 
 <script>
 
-    function defaultChartConfig(containerId, data) {
+    function defaultChartConfig(containerId, data, spots) {
         nv.addGraph(function() {
 
             var chart = nv.models.sparklinePlus();
             chart.margin({left:70})
-                .x(function(d,i) { return i })
+                .x(function(d,i) { return d.x })
                 .showLastValue(true)
                 .xTickFormat(function(d) {
-                    return d3.time.format('%x')(new Date(data[d].x))
-                });
+                    return d3.time.format('%x')(new Date(d))
+                }).spots(spots);
 
             d3.select(containerId)
                     .datum(data)
@@ -52,7 +62,7 @@
         });
     }
 
-    defaultChartConfig("#chart1",sine());
+    defaultChartConfig("#chart1", sine(), spots());
     defaultChartConfig("#chart2", volatileChart(130.0, 0.02));
     defaultChartConfig("#chart3", volatileChart(25.0, 0.09,30));
 
@@ -60,11 +70,26 @@
         var sin = [];
         var now =+new Date();
 
-        for (var i = 0; i < 100; i++) {
+        for (var i = 0; i < 200; i++) {
             sin.push({x: now + i * 1000 * 60 * 60 * 24, y: Math.sin(i/10)});
         }
 
         return sin;
+    }
+
+    function spots() {
+        var s = [];
+        var now =+new Date();
+
+        for (var i = 0; i < 200; i+= 10) {
+            s.push({
+                x: now + i * 1000 * 60 * 60 * 24,
+                y: 5 * Math.cos(i/10) + Math.sin(i/10),
+                cssClass: i % 15 ? 'red' : 'blue'
+            });
+        }
+
+        return s;
     }
 
     function volatileChart(startPrice, volatility, numPoints) {

--- a/examples/sparklinePlus.html
+++ b/examples/sparklinePlus.html
@@ -70,7 +70,7 @@
         var sin = [];
         var now =+new Date();
 
-        for (var i = 0; i < 200; i++) {
+        for (var i = 0; i < 100; i++) {
             sin.push({x: now + i * 1000 * 60 * 60 * 24, y: Math.sin(i/10)});
         }
 
@@ -81,7 +81,7 @@
         var s = [];
         var now =+new Date();
 
-        for (var i = 0; i < 200; i+= 10) {
+        for (var i = 0; i < 100; i+= 10) {
             s.push({
                 x: now + i * 1000 * 60 * 60 * 24,
                 y: 5 * Math.cos(i/10) + Math.sin(i/10),

--- a/examples/sparklinePlus.html
+++ b/examples/sparklinePlus.html
@@ -40,6 +40,7 @@
 <p><svg id="chart1" class="sparkline"></svg></p>
 <p><svg id="chart2" class="sparkline"></svg></p>
 <p><svg id="chart3" class="sparkline"></svg></p>
+<p><svg id="chart4" class="sparkline"></svg></p>
 
 <script>
 
@@ -62,9 +63,10 @@
         });
     }
 
-    defaultChartConfig("#chart1", sine(), spots());
+    defaultChartConfig("#chart1", sine());
     defaultChartConfig("#chart2", volatileChart(130.0, 0.02));
     defaultChartConfig("#chart3", volatileChart(25.0, 0.09,30));
+    defaultChartConfig("#chart4", sine(), spots());
 
     function sine() {
         var sin = [];

--- a/src/css/sparkline.css
+++ b/src/css/sparkline.css
@@ -3,6 +3,11 @@
     fill: none;
 }
 
+.nvd3.nv-sparkline .nv-spot {
+    stroke: #808080;
+    fill: #808080;
+}
+
 .nvd3.nv-sparklineplus g.nv-hoverValue {
     pointer-events: none;
 }

--- a/test/mocha/sparkline.coffee
+++ b/test/mocha/sparkline.coffee
@@ -24,6 +24,11 @@ describe 'NVD3', ->
             alignValue: true
             rightAlignValue: false
             noData: 'No Data Available'
+            spots: [
+              {x: 2, y: 100}
+              {x: 5, y: 120}
+              {x: 20, y: 150}
+            ]
 
         builder = null
         beforeEach ->
@@ -59,6 +64,7 @@ describe 'NVD3', ->
             '.nv-maxValue'
             '.nv-currentValue'
             '.nv-valueWrap'
+            '.nv-spot'
           ]
           for cssClass in cssClasses
             do(cssClass) ->


### PR DESCRIPTION
Allow users to pass additional array of points 'spots' to sparkline.

Spots are rendered on the sparkline area. You can pass cssClass attr within a spot object to apply some style.

## Preview
<img width="451" alt="screen shot 2016-02-25 at 19 03 09" src="https://cloud.githubusercontent.com/assets/1842735/13325345/7764edbc-dbf2-11e5-8c60-b873560bfe53.png">


## Example configuration

Styles:
`
.nvd3.nv-sparkline .nv-spot.odd {
   stroke: green;
   fill: #green;
}
`
`
.nvd3.nv-sparkline .nv-spot.even {
   stroke: blue;
   fill: blue;
}
`

```javascript
nv.addGraph({
        generate: function () {

            var spots = [];
            for (var i = 0; i < 20; ++i) {
                spots.push({
                    x: i * 5,
                    y: Math.cos(i * 2),
                    cssClass: i % 2 ? 'odd' : 'even'
                });
            }

            var chart = nv.models.sparkline()
                    .width(400)
                    .height(30)
                    .spots(spots);

            d3.select(chartId)
                    .datum(sine())
                    .call(chart);

            return chart;
        }
    });
```