### PR TITLE
Pass the data through to sparklineHover and updateValueLine

### DIFF
--- a/src/models/sparklinePlus.js
+++ b/src/models/sparklinePlus.js
@@ -95,7 +95,7 @@ nv.models.sparklinePlus = function() {
             }
 
             gEnter.select('.nv-hoverArea').append('rect')
-                .on('mousemove', sparklineHover)
+                .on('mousemove', function() {return sparklineHover} (data))
                 .on('click', function() { paused = !paused })
                 .on('mouseout', function() { index = []; updateValueLine(); });
 
@@ -105,7 +105,7 @@ nv.models.sparklinePlus = function() {
                 .attr('height', availableHeight + margin.top);
 
             //index is currently global (within the chart), may or may not keep it that way
-            function updateValueLine() {
+            function updateValueLine(data) {
                 if (paused) return;
 
                 var hoverValue = g.selectAll('.nv-hoverValue').data(index);
@@ -154,7 +154,7 @@ nv.models.sparklinePlus = function() {
                     .text(yTickFormat(sparkline.y()(data[index[0]], index[0])));
             }
 
-            function sparklineHover() {
+            function sparklineHover(data) {
                 if (paused) return;
 
                 var pos = d3.mouse(this)[0] - margin.left;
@@ -172,7 +172,7 @@ nv.models.sparklinePlus = function() {
                 }
 
                 index = [getClosestIndex(data, Math.round(x.invert(pos)))];
-                updateValueLine();
+                updateValueLine(data);
             }
 
         });


### PR DESCRIPTION
A sparklinePlus would keep using the original data for the hover values once the data was updated. Due to scoping. This fixes this by passing through the latest data to the sparklineHover and updateValueLine functions.
This is a fix for  [issue 1558](https://github.com/novus/nvd3/issues/1558)
