### PR TITLE
Add duration option for scatterChart model

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -41,7 +41,8 @@ nv.models.scatter = function() {
         , useVoronoi   = true
         , duration     = 250
         , interactiveUpdateDelay = 300
-        , showLabels    = false 
+        , showLabels    = false
+        , fillOpacity   = 0.5
         ;
 
 
@@ -410,7 +411,7 @@ nv.models.scatter = function() {
                 .style('fill', function(d,i) { return color(d, i) })
                 .style('stroke', function(d,i) { return color(d, i) })
                 .style('stroke-opacity', 1)
-                .style('fill-opacity', .5);
+                .style('fill-opacity', fillOpacity);
 
             // create the points, maintaining their IDs from the original data set
             var points = groups.selectAll('path.nv-point')
@@ -586,6 +587,7 @@ nv.models.scatter = function() {
         showVoronoi:   {get: function(){return showVoronoi;}, set: function(_){showVoronoi=_;}},
         id:           {get: function(){return id;}, set: function(_){id=_;}},
         interactiveUpdateDelay: {get:function(){return interactiveUpdateDelay;}, set: function(_){interactiveUpdateDelay=_;}},
+        fillOpacity: {get: function(){return fillOpacity;}, set: function(_){fillOpacity=_;}},
         showLabels: {get: function(){return showLabels;}, set: function(_){ showLabels = _;}},
 
         // simple functor options

--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -361,7 +361,6 @@ nv.models.scatterChart = function() {
         showYAxis:  {get: function(){return showYAxis;}, set: function(_){showYAxis=_;}},
         defaultState:     {get: function(){return defaultState;}, set: function(_){defaultState=_;}},
         noData:     {get: function(){return noData;}, set: function(_){noData=_;}},
-        duration:   {get: function(){return duration;}, set: function(_){duration=_;}},
         showLabels: {get: function(){return showLabels;}, set: function(_){showLabels=_;}},
 
         // options that require extra logic in the setter
@@ -374,6 +373,11 @@ nv.models.scatterChart = function() {
         rightAlignYAxis: {get: function(){return rightAlignYAxis;}, set: function(_){
             rightAlignYAxis = _;
             yAxis.orient( (_) ? 'right' : 'left');
+        }},
+        duration: {get: function(){return duration;}, set: function(_){
+            duration=_;
+            renderWatch.reset(duration);
+            scatter.duration(duration);
         }},
         color: {get: function(){return color;}, set: function(_){
             color = nv.utils.getColor(_);


### PR DESCRIPTION
The scatterChart model's duration setter was not causing any effect in the chart.
Now the setter updates the duration value for the scatter model, which conditions the duration for the scatterChart.