### PR TITLE
fixed issue when printing from firefox

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -89,3 +89,13 @@ svg.nvd3-svg {
     fill-opacity: .7;
 }
 
+/**********
+*  Print
+*/
+
+@media print {
+  .nvd3 text {
+    stroke-width: 0;
+    fill-opacity: 1;
+  }
+}


### PR DESCRIPTION
There is an issue when printing the discrete bar chart from Firefox where the bar label text gets garbled (see attached screenshots). This small css change resolves the issue. 

![before](https://cloud.githubusercontent.com/assets/2729624/14060674/0a8002c4-f342-11e5-9fb1-c86b4d4415a4.png)
![after](https://cloud.githubusercontent.com/assets/2729624/14060676/0ecdaeb2-f342-11e5-9e47-6a04f4e06d34.png)
