### PR TITLE
 Fixed issue #1606: Line Chart interactive guideline does not highlight hover point when some series are disabled

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -383,11 +383,17 @@ nv.models.lineChart = function() {
                 var singlePoint, pointIndex, pointXLocation, allData = [];
                 data
                     .filter(function(series, i) {
-                        // Assign the index here instead of in the filter
-                        // as the DOM removes disabled series
-                        return !series.disabled && !series.disableTooltip;
+                        // Assign a color index to the series if it's not disabled
+                        // to use for the tooltip colors rather than the series index
+                        if(!series.disabled && !series.disableTooltip) {
+                            series.colorIndex = i;
+                            return series
+                        }
                     })
                     .forEach(function(series,i) {
+                        // Assign the index here instead of in the filter
+                        // as the DOM removes disabled series
+                        series.seriesIndex = i;
                         var extent = focusEnable ? (brush.empty() ? x2.domain() : brush.extent()) : x.domain();
                         var currentValues = series.values.filter(function(d,i) {
                             return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
@@ -403,11 +409,10 @@ nv.models.lineChart = function() {
                         if (singlePoint === undefined) singlePoint = point;
                         if (pointXLocation === undefined) pointXLocation = chart.xScale()(chart.x()(point,pointIndex));
                         // Use the original data index rather than filtered series index for the color
-                        var colorIndex = data.findIndex(function(d) { return d.key === series.key });
                         allData.push({
                             key: series.key,
                             value: pointYValue,
-                            color: color(series, colorIndex),
+                            color: color(series, series.colorIndex),
                             data: point
                         });
                     });

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -383,7 +383,8 @@ nv.models.lineChart = function() {
                 var singlePoint, pointIndex, pointXLocation, allData = [];
                 data
                     .filter(function(series, i) {
-                        series.seriesIndex = i;
+                        // Assign the index here instead of in the filter
+                        // as the DOM removes disabled series
                         return !series.disabled && !series.disableTooltip;
                     })
                     .forEach(function(series,i) {
@@ -401,10 +402,12 @@ nv.models.lineChart = function() {
                         if (point === undefined) return;
                         if (singlePoint === undefined) singlePoint = point;
                         if (pointXLocation === undefined) pointXLocation = chart.xScale()(chart.x()(point,pointIndex));
+                        // Use the original data index rather than filtered series index for the color
+                        var colorIndex = data.findIndex(function(d) { return d.key === series.key });
                         allData.push({
                             key: series.key,
                             value: pointYValue,
-                            color: color(series,series.seriesIndex),
+                            color: color(series, colorIndex),
                             data: point
                         });
                     });


### PR DESCRIPTION
Fixed the issue by assigning the series index inside the `forEach` rather than filter and using the data index rather than series index for the tooltip color.

I have checked in the build files so I can use this commit in my project today. Advise if you'd like me to remove them before you merge.

Cheers, Danielle
