### PR TITLE
Bugfix in initTooltip() function

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -247,7 +247,7 @@ nv.models.tooltip = function() {
 
     // Creates new tooltip container, or uses existing one on DOM.
     function initTooltip() {
-        if (!tooltip || !tooltip.node()) {
+        if (!tooltip || !tooltip.node() || d3.select('.nvtooltip#'+id)[0][0] === null) {
             var container = chartContainer ? chartContainer : document.body;
             // Create new tooltip div if it doesn't exist on DOM.
 

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -247,7 +247,7 @@ nv.models.tooltip = function() {
 
     // Creates new tooltip container, or uses existing one on DOM.
     function initTooltip() {
-        if (!tooltip || !tooltip.node() || d3.select('.nvtooltip#'+id)[0][0] === null) {
+        if (!tooltip || !tooltip.node() || d3.select('.nvtooltip#'+id).empty()) {
             var container = chartContainer ? chartContainer : document.body;
             // Create new tooltip div if it doesn't exist on DOM.
 


### PR DESCRIPTION
![consol](https://cloud.githubusercontent.com/assets/14055200/14886790/ebbc32c4-0d52-11e6-80b2-c251f14503bb.png)
![js](https://cloud.githubusercontent.com/assets/14055200/14886789/ebbad118-0d52-11e6-9b9b-fece7c3b303e.png)

When there are several charts, they share the same tooltip! In some exceptional cases, DOM element is removed but NDV3 tooltip object still exist! This causes initTooltip function to not create new tooltip. As the result, NVD3 tooltip object will be updated but since it doesn't exist in DOM elements it won't be shown anywehre.

As you can see in attached files, when it happens that the tooltip DOM elements is removed (I don't know who!), NVD3 tooltip object still contains it's value but if you try to find it via JQuery or d3.select, there is no such element in DOM.
