### PR TITLE
Fix lineWithFocusChart rendering issues

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -45,7 +45,7 @@ nv.models.lineChart = function() {
     }).headerFormatter(function(d, i) {
         return xAxis.tickFormat()(d, i);
     });
-    
+
     interactiveLayer.tooltip.valueFormatter(function(d, i) {
         return yAxis.tickFormat()(d, i);
     }).headerFormatter(function(d, i) {
@@ -87,7 +87,7 @@ nv.models.lineChart = function() {
             nv.utils.initSVG(container);
             var availableWidth = nv.utils.availableWidth(width, container, margin),
                 availableHeight = nv.utils.availableHeight(height, container, margin) - (focusEnable ? focus.height() : 0);
-            chart.update = function() { 
+            chart.update = function() {
                 if( duration === 0 ) {
                     container.call( chart );
                 } else {
@@ -122,6 +122,11 @@ nv.models.lineChart = function() {
             } else {
                 container.selectAll('.nv-noData').remove();
             }
+
+            /* Update `main' graph on brush update. */
+            focus.dispatch.on("onBrush", function(extent) {
+                onBrush(extent);
+            });
 
             // Setup Scales
             x = lines.xScale();
@@ -188,7 +193,7 @@ nv.models.lineChart = function() {
             g.select('.nv-focus .nv-background rect')
                 .attr('width', availableWidth)
                 .attr('height', availableHeight);
-                
+
             lines
                 .width(availableWidth)
                 .height(availableHeight)
@@ -237,7 +242,7 @@ nv.models.lineChart = function() {
                 ;
               }
             }
-            
+
             g.select('.nv-focus .nv-x.nv-axis')
                 .attr('transform', 'translate(0,' + availableHeight + ')');
 
@@ -355,11 +360,6 @@ nv.models.lineChart = function() {
                 lines.clearHighlights();
             });
 
-            /* Update `main' graph on brush update. */
-            focus.dispatch.on("onBrush", function(extent) {
-                onBrush(extent);
-            });
-
             dispatch.on('changeState', function(e) {
                 if (typeof e.disabled !== 'undefined' && data.length === e.disabled.length) {
                     data.forEach(function(series,i) {
@@ -374,7 +374,7 @@ nv.models.lineChart = function() {
             //============================================================
             // Functions
             //------------------------------------------------------------
-    
+
             // Taken from crossfilter (http://square.github.com/crossfilter/)
             function resizePath(d) {
                 var e = +(d == 'e'),
@@ -390,7 +390,7 @@ nv.models.lineChart = function() {
                     + 'M' + (4.5 * x) + ',' + (y + 8)
                     + 'V' + (2 * y - 8);
             }
-            
+
             function onBrush(extent) {
                 // Update Main (Focus)
                 var focusLinesWrap = g.select('.nv-focus .nv-linesWrap')
@@ -409,7 +409,7 @@ nv.models.lineChart = function() {
                         })
                 );
                 focusLinesWrap.transition().duration(duration).call(lines);
-    
+
                 // Update Main (Focus) Axes
                 updateXAxis();
                 updateYAxis();
@@ -539,6 +539,6 @@ nv.models.lineChart = function() {
 
 nv.models.lineWithFocusChart = function() {
   return nv.models.lineChart()
-    .margin({ bottom: 30 }) 
+    .margin({ bottom: 30 })
     .focusEnable( true );
 };


### PR DESCRIPTION
This commit fixes a rendering issue wit the lineWithFocusChart.
When a lineWithFocusChart initially has no data, then gets data and
update() is called, only the focus part is rendered. Only when data is
set again and update() is called again does the 'normal' linechart
show correctly.
Listening for the 'onBrush' event of the focus before initializing the
chart seems to fix the issue.