### PR TITLE
Sunburst: when zoomed, show tooltip only for nodes in current view

### DIFF
--- a/src/models/sunburst.js
+++ b/src/models/sunburst.js
@@ -249,6 +249,12 @@ nv.models.sunburst = function() {
                 .style("stroke", "#FFF")
                 .on("click", zoomClick)
                 .on('mouseover', function(d,i){
+                    var startAngle = Math.max(0, Math.min(2 * Math.PI, x(d.x)));
+                    var endAngle = Math.max(0, Math.min(2 * Math.PI, x(d.x + d.dx)));
+                    if (startAngle == endAngle) {
+                        //this node is hidden from the current zoomed view, don't show its tooltip
+                        return;
+                    }
                     d3.select(this).classed('hover', true).style('opacity', 0.8);
                     dispatch.elementMouseover({
                         data: d,


### PR DESCRIPTION
This commit improves the showing of tooltips in Sunburst charts.
When the Sunburst chart is zoomed and the mouse is hovering around
"12 o'clock", a tooltip is shown for nodes that shouldn't be in the
current view. This is because those <g>'s are not hidden, but their
startAngle and endAngle are the same so they are not visible.
To reproduce, open the sunburst.html example and click on the "animate"
node. The sunburst is now zoomed and only shows orange nodes.
Now hover your mouse on the top around the top north point, and you will
see tooltips from the adjacent node, "analytics", in green.

This commit fixes this issue by checking onMouseOver if the startAngle
and endAngle are equal. If so, the node does not belong to the current
view.