### PR TITLE
linePlusBarChart: tooltip and ticks have are flipped axis (Reverting #1518)

### DIFF
--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -70,13 +70,13 @@ nv.models.linePlusBarChart = function() {
     //------------------------------------------------------------
 
     var getBarsAxis = function() {
-        return !switchYAxisOrder
+        return switchYAxisOrder
             ? { main: y2Axis, focus: y4Axis }
             : { main: y1Axis, focus: y3Axis }
     }
 
     var getLinesAxis = function() {
-        return !switchYAxisOrder
+        return switchYAxisOrder
             ? { main: y1Axis, focus: y3Axis }
             : { main: y2Axis, focus: y4Axis }
     }


### PR DESCRIPTION
The Change reverts #1518.

The result of this change is that the `tooltip` and `ticks` are always flipped. (`y1Axis.tickFormat` used by the `tooltip` in `y2Axis` and vice versa)

Because `getBarsAxis` und `getLinesAxis` are only used by the tooltip it shouldn't affect anything else.

Example (`nvd3-community`-Example against `1.8.3`)
http://plnkr.co/edit/aJ0BLI8QPBLprXTtpokV?p=preview

Example with fix applied:
http://plnkr.co/edit/MTsl4q9fiobyHUZVUaOm?p=preview

Alternatively just revert the commit. ;)