### PR TITLE
transitionDuration is obsolete

### DIFF
--- a/examples/lineChart.html
+++ b/examples/lineChart.html
@@ -56,7 +56,7 @@
     nv.addGraph(function() {
         chart = nv.models.lineChart()
             .options({
-                transitionDuration: 300,
+                duration: 300,
                 useInteractiveGuideline: true
             })
         ;


### PR DESCRIPTION
This caught me a second time, and still trips people up who follow the advice to download the repo and run examples locally.