### PR TITLE
Allow configuration of chartContainer for interactiveGuideline tooltip in lineChart

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -315,7 +315,7 @@ nv.models.lineChart = function() {
                 };
 
                 interactiveLayer.tooltip
-                    .chartContainer(chart.container.parentNode)
+                    .chartContainer(interactiveLayer.tooltip.chartContainer() || chart.container.parentNode)
                     .valueFormatter(interactiveLayer.tooltip.valueFormatter() || defaultValueFormatter)
                     .data({
                         value: chart.x()( singlePoint,pointIndex ),


### PR DESCRIPTION
As seen in Netflix/vector#55, the problem of the interactive guideline tooltip being behind a widget, at least in regards to [ManifestWebDesign/angular-gridster](https://github.com/ManifestWebDesign/angular-gridster), is not overridable in the current release of this library.  This pull-request allows overriding to take place for the lineChart model, just like the #1247 change.