### PR TITLE
Pass more data to color method to allow greater customization and consistency

### DIFF
--- a/src/models/sunburst.js
+++ b/src/models/sunburst.js
@@ -235,15 +235,15 @@ nv.models.sunburst = function() {
 
             cGE.append("path")
                 .attr("d", arc)
-                .style("fill", function (d) {
+                .style("fill", function (d, i) {
                     if (d.color) {
                         return d.color;
                     }
                     else if (groupColorByParent) {
-                        return color((d.children ? d : d.parent).name);
+                        return color((d.children ? d : d.parent), i);
                     }
                     else {
-                        return color(d.name);
+                        return color(d, i);
                     }
                 })
                 .style("stroke", "#FFF")


### PR DESCRIPTION
This fix passes the entire data object and index into the color function rather than just the name. In addition to to allowing more intelligent color functions, this change makes the API more consistent with the pie chart.

The motivation for this change is to be able to use an attribute of the data passed in to generate the fill colors for the sections in order to signify intensity.

BREAKING CHANGE:

Any existing sunburst chart that uses a custom color function will need to be updated to the new API; however, the name is still passed to this function as an attribute of the object. Migration is as simple as changing 

```
function(name) {
  // ...
}
```
to
```
function(data) {
  var name = data.name;
  // ...
}
```

I would also like to note that in the current state, it seems unlikely anyone would be using a node name to do any sort of color calculation/generation.
