### PR TITLE
Fixes  #1692 (isMSIE bugfix breaks tooltip in IE11)

### DIFF
--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -17,7 +17,7 @@ nv.interactiveGuideline = function() {
         ,   showGuideLine = true
         ,   svgContainer = null // Must pass the chart's svg, we'll use its mousemove event.
         ,   tooltip = nv.models.tooltip()
-        ,   isMSIE = "ActiveXObject" in window // Checkt if IE by looking for activeX.
+        ,   isMSIE =  window.ActiveXObject// Checkt if IE by looking for activeX. (excludes IE11)
     ;
 
     tooltip


### PR DESCRIPTION
Check for activeXobject on window object, will return false for IE11