### PR TITLE
linePlusBarChart: need to pass along "strokeWidth" while rendering line

### DIFF
--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -450,6 +450,7 @@ nv.models.linePlusBarChart = function() {
                                 return {
                                     area: d.area,
                                     fillOpacity: d.fillOpacity,
+                                    strokeWidth: d.strokeWidth,
                                     key: d.key,
                                     values: d.values.filter(function(d,i) {
                                         return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];


### PR DESCRIPTION
@liquidpele while trying to customize the line width in a linePlusBarChart, I noticed the `stroke-width` of the line is unaffected although the property `strokeWidth` is set on the chartData. This PR should fix the bug.