### PR TITLE
Make multiBarChart use the same tooltip regardless of whether or not interactiveGuideline is enabled.

### DIFF
--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -211,7 +211,12 @@ nv.interactiveGuideline = function() {
     }
 
     layer.dispatch = dispatch;
-    layer.tooltip = tooltip;
+
+    layer.tooltip = function(_) {
+        if (!arguments.length) return tooltip;
+        tooltip = _;
+        return layer;
+    };
 
     layer.margin = function(_) {
         if (!arguments.length) return margin;

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -291,7 +291,8 @@ nv.models.multiBarChart = function() {
                     .height(availableHeight)
                     .margin({left:margin.left, top:margin.top})
                     .svgContainer(container)
-                    .xScale(x);
+                    .xScale(x)
+                    .tooltip(tooltip);
                 wrap.select(".nv-interactive").call(interactiveLayer);
             }
 
@@ -373,7 +374,7 @@ nv.models.multiBarChart = function() {
                             });
                         });
 
-                    interactiveLayer.tooltip
+                    interactiveLayer.tooltip()
                         .data({
                             value: xValue,
                             index: pointIndex,
@@ -384,7 +385,7 @@ nv.models.multiBarChart = function() {
                 });
 
                 interactiveLayer.dispatch.on("elementMouseout",function(e) {
-                    interactiveLayer.tooltip.hidden(true);
+                    interactiveLayer.tooltip().hidden(true);
                 });
             }
             else {


### PR DESCRIPTION
It seems that when `useInteractiveGuideline` is true in a multiBarChart, the tooltip belongs to the interactive layer, rather than the chart, causing customizations made to the chart to be missing from the tooltip as it is displayed.

At least that's how it seems to me, but I am very new to this library and probably might be wrong about everything.  In any event, this pull request is my suggestion for a fix that, again, seems to work to me.

**Warning** this is only a partial solution.  I know nothing about _JavaScript_ testing so I only made the changes to the multiBarChart.  The other charts use also the tooltip, so I'm sure they would be broken by this change.  Maybe this should be an issue rather than a pull request.

I strongly encourage someone who knows more that I do to understand what is actually causing the phenomenon that this pull request attempts to address and to implement an actually correct solution.