### PR TITLE
Make multiBarChart defer to y-Axis tick format for interactiveLayer tooltip value formatting

### DIFF
--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -62,6 +62,15 @@ nv.models.multiBarChart = function() {
             return xAxis.tickFormat()(d, i);
         });
 
+    interactiveLayer.tooltip
+        .duration(0)
+        .valueFormatter(function(d, i) {
+            return yAxis.tickFormat()(d, i);
+        })
+        .headerFormatter(function(d, i) {
+            return xAxis.tickFormat()(d, i);
+        });
+
     controls.updateState(false);
 
     //============================================================


### PR DESCRIPTION
This purpose of this pull-request is consistency between line-charts and bar-charts with regard to the formatting of values within a pop-up tooltip when `useInteractiveGuideline` is enabled.

See [lines 49](https://github.com/novus/nvd3/blob/master/src/models/lineChart.js#L49) through [53 of `lineChart.js`](https://github.com/novus/nvd3/blob/master/src/models/lineChart.js#L49), where the tick-formatter for the y-axis is used as the value formatter for the interactive-layer's tooltip value-formatter, and which is a repeat of [the immediately preceding stanza](https://github.com/novus/nvd3/blob/master/src/models/lineChart.js#L43) where the same y-axis value formatting is assigned for use by the tooltip when the interactive-layer is absent.

The first of these two line-chart stanzas currently appears in the code for the `multiBarChart` (see [line 53 of `mutiBarChart.js`](https://github.com/novus/nvd3/blob/master/src/models/multiBarChart.js#L56) while the second is absent.  The consequence is that line-charts and bar-charts both use the y-axis tick formatter for formatting tooltip values when `useInteractiveGuideline` is **dis**abled, but if `useInteractiveGuideline` is **en**abled then the line chart behaves one way, using the y-axis tick formatter for its tooltip values, while the bar chart simply displays an unformatted value (see [line 41 of `tooltip.js`](https://github.com/novus/nvd3/blob/master/src/tooltip.js#L41)).

This pull request repeats the `interactiveLayer`-specific value-formatting code from the line-chart definition into the multi-bar-chart definition so that a user can switch between the two chart-types without affecting value formatting in tooltips regardless of whether or not `useInteractiveGuideline` is enabled.