### PR TITLE
Remove my email address for blog post

### DIFF
--- a/blog/2014/03/nvd3-issues-triage/index.html
+++ b/blog/2014/03/nvd3-issues-triage/index.html
@@ -236,7 +236,7 @@ Our expectation with new features will be to move them to the roadmap and priori
   
 
 
-<span class="byline author vcard">Posted by <span class="fn"><a href="mailto:sepi@joesepi.com">joesepi</a></span></span>
+<span class="byline author vcard">Posted by <span class="fn">joesepi</span></span>
 
       
 


### PR DESCRIPTION
I am getting emails from users with issues. I'd like to remove my email address from this blog post. Thanks.