### PR TITLE
fix #1740: Wrong interactiveGuideline tooltip header with multiple datasets that span different domains in lineChart

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -278,6 +278,7 @@ nv.models.lineChart = function() {
             interactiveLayer.dispatch.on('elementMousemove', function(e) {
                 lines.clearHighlights();
                 var singlePoint, pointIndex, pointXLocation, allData = [];
+                var maxSeriesSize = -1;
                 data
                     .filter(function(series, i) {
                         series.seriesIndex = i;
@@ -296,7 +297,14 @@ nv.models.lineChart = function() {
                             lines.highlightPoint(series.seriesIndex, pointIndex, true);
                         }
                         if (point === undefined) return;
-                        if (singlePoint === undefined) singlePoint = point;
+
+                        // X value from biggest series should be used for tooltip header
+                        if (currentValues.length > maxSeriesSize || singlePoint === undefined) {
+                            maxSeriesSize = currentValues.length;
+                            singlePoint = point;
+                        }
+                        //if (singlePoint === undefined) singlePoint = point;
+
                         if (pointXLocation === undefined) pointXLocation = chart.xScale()(chart.x()(point,pointIndex));
                         allData.push({
                             key: series.key,


### PR DESCRIPTION
Fix for issue #1740 

I don't quite have time to write tests but I just wanted to submit the PR to show how I fixed the bug on my own build in case it inspires anyone. Basically the code iterates through each series but only sets the "singlePoint" variable once if it's undefined. If there's many data series and the later ones have a larger domain, the singlePoint variable from the earlier series will be passed to the tooltip (on line 325) and the wrong value of "X" will be shown on the header.

The issue may exist for other types of charts, I will verify that later.