### PR TITLE
Enable label support in StackedArea and Line

### DIFF
--- a/src/models/line.js
+++ b/src/models/line.js
@@ -29,6 +29,7 @@ nv.models.line = function() {
     scatter
         .pointSize(16) // default size
         .pointDomain([16,256]) //set to speed up calculation, needs to be unset if there is a custom size accessor
+        .showLabels(true)
     ;
 
     //============================================================

--- a/src/models/stackedArea.js
+++ b/src/models/stackedArea.js
@@ -30,6 +30,7 @@ nv.models.stackedArea = function() {
     scatter
         .pointSize(2.2) // default size
         .pointDomain([2.2, 2.2]) // all the same size by default
+        .showLabels(true)
     ;
 
     /************************************


### PR DESCRIPTION
This commit tries to resolve #479

- Label will be automatically added to scatter point, when values have label data
- For example {x: 2, y: 3, label: "label"}