### PR TITLE
Change d3 variable scope

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -13,7 +13,7 @@ nv.dom = {}; //DOM manipulation functions
 
 // Node/CommonJS - require D3
 if (typeof(module) !== 'undefined' && typeof(exports) !== 'undefined' && typeof(d3) == 'undefined') {
-    d3 = require('d3');
+    var d3 = require('d3');
 }
 
 nv.dispatch = d3.dispatch('render_start', 'render_end');


### PR DESCRIPTION
Declaring d3 as a global variable like this is unnecessary and causes memory leak detectors (like Hapi's Lab) to fail.