### PR TITLE
Fix renderEnd not being rendered when showLabels is false 

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -210,7 +210,7 @@ nv.models.pie = function() {
             });
 
             slices.select('path')
-                .transition()
+                .watchTransition(renderWatch, 'pie labels')
                 .duration(duration)
                 .attr('d', function (d, i) { return arcs[i](d); })
                 .attrTween('d', arcTween);

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -210,7 +210,7 @@ nv.models.pie = function() {
             });
 
             slices.select('path')
-                .watchTransition(renderWatch, 'pie labels')
+                .watchTransition(renderWatch, 'pie slices')
                 .duration(duration)
                 .attr('d', function (d, i) { return arcs[i](d); })
                 .attrTween('d', arcTween);


### PR DESCRIPTION
When showLabels is false, there would no longer be any watchTransition calls and as a result renderEnd would never be triggered.
