### PR TITLE
fixing multiBar tooltip formatting

### DIFF
--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -62,6 +62,14 @@ nv.models.multiBarChart = function() {
             return xAxis.tickFormat()(d, i);
         });
 
+    interactiveLayer.tooltip
+        .valueFormatter(function (d, i) {
+            return d == null ? "N/A" : yAxis.tickFormat()(d, i);
+        })
+        .headerFormatter(function (d, i) {
+            return xAxis.tickFormat()(d, i);
+        });
+
     controls.updateState(false);
 
     //============================================================


### PR DESCRIPTION
allowing users to set valueFormatter for interactiveLayer.tooltip (it was previously being overwritten)

This change should also be implemented on other charts that use interactiveLayer.tooltip