### PR TITLE
fix: Line chart interactive guideline error when extent is not in ascending order

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -285,11 +285,13 @@ nv.models.lineChart = function() {
                     })
                     .forEach(function(series,i) {
                         var extent = focusEnable ? (focus.brush.empty() ? focus.xScale().domain() : focus.brush.extent()) : x.domain();
-                        if (extent[0] > extent[1])
-                            extent.reverse();
-
                         var currentValues = series.values.filter(function(d,i) {
-                            return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
+                            // check if point is between the extent
+                            if(extent[0] <= extent[1]) {
+                                return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
+                            } else {
+                                return lines.x()(d,i) >= extent[1] && lines.x()(d,i) <= extent[0];                                
+                            }
                         });
 
                         pointIndex = nv.interactiveBisect(currentValues, e.pointXValue, lines.x());

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -286,7 +286,8 @@ nv.models.lineChart = function() {
                     .forEach(function(series,i) {
                         var extent = focusEnable ? (focus.brush.empty() ? focus.xScale().domain() : focus.brush.extent()) : x.domain();
                         var currentValues = series.values.filter(function(d,i) {
-                            // check if point is between the extent
+                            // Checks if the x point is between the extents, handling case where extent[0] is greater than extent[1] 
+                            // (e.g. x domain is manually set to reverse the x-axis)
                             if(extent[0] <= extent[1]) {
                                 return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
                             } else {

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -285,6 +285,9 @@ nv.models.lineChart = function() {
                     })
                     .forEach(function(series,i) {
                         var extent = focusEnable ? (focus.brush.empty() ? focus.xScale().domain() : focus.brush.extent()) : x.domain();
+                        if (extent[0] > extent[1])
+                            extent.reverse();
+
                         var currentValues = series.values.filter(function(d,i) {
                             return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];
                         });


### PR DESCRIPTION
Fixes a “TypeError: Cannot read property 'x' of undefined” error when
using the interactive guideline for line charts if the extent is not in
ascending order.

In our use case, we reversed the x-axis on the line chart by reversing
the x domain.  This caused series.values.filter to filter out all our
values and result in the TypeError when calling interactiveBisect  A
check was added to ensure the extent is in ascending order.