### PR TITLE
Fix 1243: LineWithFocus: chart doesn't update if the focus area is less than 1 even if chart is all decimals

### DIFF
--- a/src/models/focus.js
+++ b/src/models/focus.js
@@ -210,12 +210,6 @@ nv.models.focus = function(content) {
             function onBrush(shouldDispatch) {
                 brushExtent = brush.empty() ? null : brush.extent();
                 var extent = brush.empty() ? x.domain() : brush.extent();
-
-                //The brush extent cannot be less than one.  If it is, don't update the line chart.
-                if (Math.abs(extent[0] - extent[1]) <= 1) {
-                    return;
-                }
-
                 dispatch.brush({extent: extent, brush: brush});
                 updateBrushBG();
                 if (shouldDispatch) {

--- a/src/models/focus.js
+++ b/src/models/focus.js
@@ -105,11 +105,7 @@ nv.models.focus = function(content) {
 
             brush.on('brushend', function () {
                 if (!syncBrushing) {
-                    var extent = brush.empty() ? x.domain() : brush.extent();
-                    if (Math.abs(extent[0] - extent[1]) <= 1) {
-                        return;
-                    }
-                    dispatch.onBrush(extent);
+                    dispatch.onBrush(brush.empty() ? x.domain() : brush.extent());
                 }
             });
 


### PR DESCRIPTION
@liquidpele See discussion [here](https://github.com/novus/nvd3/issues/1243) and [here](https://github.com/novus/nvd3/issues/955). This is a "quick and dirty" fix in that it simply removes the offending lines. 