### PR TITLE
Fix point update bug in scatter model

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -51,6 +51,7 @@ nv.models.scatter = function() {
     //------------------------------------------------------------
 
     var x0, y0, z0 // used to store previous scales
+        , xDom, yDom // used to store previous domains
         , width0
         , height0
         , timeoutID
@@ -171,6 +172,16 @@ nv.models.scatter = function() {
             height0 = height0 || height;
 
             var sizeDiff = width0 !== width || height0 !== height;
+
+            // Domain Diffs
+
+            xDom = xDom || [];
+            var domainDiff = xDom[0] !== x.domain()[0] || xDom[1] !== x.domain()[1];
+            xDom = x.domain();
+
+            yDom = yDom || [];
+            domainDiff = domainDiff || yDom[0] !== y.domain()[0] || yDom[1] !== y.domain()[1];
+            yDom = y.domain();
 
             // Setup containers and skeleton of chart
             var wrap = container.selectAll('g.nv-wrap.nv-scatter').data([data]);
@@ -461,7 +472,7 @@ nv.models.scatter = function() {
                 })
                 .remove();
             // Update points position only if "x" or "y" have changed
-            points.filter(function (d) { return scaleDiff || sizeDiff || getDiffs(d, 'x', getX, 'y', getY); })
+            points.filter(function (d) { return scaleDiff || sizeDiff || domainDiff || getDiffs(d, 'x', getX, 'y', getY); })
                 .watchTransition(renderWatch, 'scatter points')
                 .attr('transform', function(d) {
                     //nv.log(d, getX(d[0],d[1]), x(getX(d[0],d[1])));


### PR DESCRIPTION
When series are toggled on and off the axis are able to dynamically resize, scaleDiff and sizeDiff do not capture this change. domainDiff added and used to determine point x,y update pruning.

Fixes #1865

This is the third bug this optimisation has caused... I'm beginning to think it wasn't such a good idea. If any more pop up I'm tempted to remove it, or at least have someone more familiar with the guts of nvd3 to check over the considerations when culling points from updates.