### PR TITLE
Scatter Model Maintainability

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -473,14 +473,33 @@ nv.models.scatter = function() {
                     return 'translate(' + nv.utils.NaNtoZero(x(getX(d[0],d[1]))) + ',' + nv.utils.NaNtoZero(y(getY(d[0],d[1]))) + ')'
                 })
                 .remove();
-            // Update points position only if "x" or "y" have changed
+
+            //============================================================
+            // Point Update Optimisation Notes
+            //------------------------------------------------------------
+            // The following update selections are filtered with getDiffs
+            // (defined at the top of this file) this brings a performance
+            // benefit for charts with large data sets that accumulate a
+            // subset of changes or additions over time.
+            //
+            // Uneccesary and expensive DOM calls are avoided by culling
+            // unchanged points from the selection in exchange for the
+            // cheaper overhead of caching and diffing each point first.
+            //
+            // Due to the way D3 and NVD3 work, other global changes need
+            // to be considered in addition to local point properties.
+            // This is a potential source of bugs (if any of the global
+            // changes that possibly affect points are missed).
+
+            // Update Point Positions [x, y]
             points.filter(function (d) { return getDiffs(d, 'x', getX, 'y', getY) || scaleDiff || sizeDiff || domainDiff; })
                 .watchTransition(renderWatch, 'scatter points')
                 .attr('transform', function(d) {
                     //nv.log(d, getX(d[0],d[1]), x(getX(d[0],d[1])));
                     return 'translate(' + nv.utils.NaNtoZero(x(getX(d[0],d[1]))) + ',' + nv.utils.NaNtoZero(y(getY(d[0],d[1]))) + ')'
                 });
-            // Update points appearance only if "shape" or "size" have changed
+
+            // Update Point Appearance [shape, size]
             points.filter(function (d) { return getDiffs(d, 'shape', getShape, 'size', getSize) || scaleDiff || sizeDiff; })
                 .watchTransition(renderWatch, 'scatter points')
                 .attr('d',

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -61,6 +61,31 @@ nv.models.scatter = function() {
         , _cache = {}
         ;
 
+    //============================================================
+    // Diff and Cache Utilities
+    //------------------------------------------------------------
+    // getDiffs is used to filter unchanged points from the update
+    // selection. It implicitly updates it's cache when called and
+    // therefor the diff is based upon the previous invocation NOT
+    // the previous update.
+    //
+    // getDiffs takes a point as its first argument followed by n
+    // key getter pairs (d, [key, get... key, get]) this approach
+    // was chosen for efficiency. (The filter will call it a LOT).
+    //
+    // It is important to call delCache on point exit to prevent a
+    // memory leak. It is also needed to prevent invalid caches if
+    // a new point uses the same series and point id key.
+    //
+    // Argument Performance Concerns:
+    // - Object property lists for key getter pairs would be very
+    // expensive (points * objects for the GC every update).
+    // - ES6 function names for implicit keys would be nice but
+    // they are not guaranteed to be unique.
+    // - function.toString to obtain implicit keys is possible
+    // but long object keys are not free (internal hash).
+    // - Explicit key without objects are the most efficient.
+
     function getCache(d) {
         var key, val;
         key = d[0].series + ':' + d[1];

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -201,7 +201,7 @@ nv.models.scatter = function() {
                 .attr('id', 'nv-edge-clip-' + id)
                 .append('rect')
                 .attr('transform', 'translate( -10, -10)');
-                
+
             wrap.select('#nv-edge-clip-' + id + ' rect')
                 .attr('width', availableWidth + 20)
                 .attr('height', (availableHeight > 0) ? availableHeight + 20 : 0);
@@ -217,10 +217,10 @@ nv.models.scatter = function() {
 
                 // inject series and point index for reference into voronoi
                 if (useVoronoi === true) {
-                    
+
                     // nuke all voronoi paths on reload and recreate them
                     wrap.select('.nv-point-paths').selectAll('path').remove();
-                    
+
                     var vertices = d3.merge(data.map(function(group, groupIndex) {
                             return group.values
                                 .map(function(point, pointIndex) {

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -517,20 +517,28 @@ nv.models.scatter = function() {
             // changes that possibly affect points are missed).
 
             // Update Point Positions [x, y]
-            points.filter(function (d) { return getDiffs(d, 'x', getX, 'y', getY) || scaleDiff || sizeDiff || domainDiff; })
-                .watchTransition(renderWatch, 'scatter points')
-                .attr('transform', function(d) {
-                    //nv.log(d, getX(d[0],d[1]), x(getX(d[0],d[1])));
-                    return 'translate(' + nv.utils.NaNtoZero(x(getX(d[0],d[1]))) + ',' + nv.utils.NaNtoZero(y(getY(d[0],d[1]))) + ')'
-                });
+            points.filter(function (d) {
+                // getDiffs must always be called to update cache
+                return getDiffs(d, 'x', getX, 'y', getY) ||
+                    scaleDiff || sizeDiff || domainDiff;
+            })
+            .watchTransition(renderWatch, 'scatter points')
+            .attr('transform', function (d) {
+                return 'translate(' +
+                    nv.utils.NaNtoZero(x(getX(d[0], d[1]))) + ',' +
+                    nv.utils.NaNtoZero(y(getY(d[0], d[1]))) + ')'
+            });
 
             // Update Point Appearance [shape, size]
-            points.filter(function (d) { return getDiffs(d, 'shape', getShape, 'size', getSize) || scaleDiff || sizeDiff; })
-                .watchTransition(renderWatch, 'scatter points')
-                .attr('d',
-                    nv.utils.symbol()
-                    .type(function(d) { return getShape(d[0]); })
-                    .size(function(d) { return z(getSize(d[0],d[1])) })
+            points.filter(function (d) {
+                // getDiffs must always be called to update cache
+                return getDiffs(d, 'shape', getShape, 'size', getSize) ||
+                    scaleDiff || sizeDiff || domainDiff;
+            })
+            .watchTransition(renderWatch, 'scatter points')
+            .attr('d', nv.utils.symbol()
+                .type(function (d) { return getShape(d[0]) })
+                .size(function (d) { return z(getSize(d[0], d[1])) })
             );
 
             // add label a label to scatter chart

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -474,14 +474,14 @@ nv.models.scatter = function() {
                 })
                 .remove();
             // Update points position only if "x" or "y" have changed
-            points.filter(function (d) { return scaleDiff || sizeDiff || domainDiff || getDiffs(d, 'x', getX, 'y', getY); })
+            points.filter(function (d) { return getDiffs(d, 'x', getX, 'y', getY) || scaleDiff || sizeDiff || domainDiff; })
                 .watchTransition(renderWatch, 'scatter points')
                 .attr('transform', function(d) {
                     //nv.log(d, getX(d[0],d[1]), x(getX(d[0],d[1])));
                     return 'translate(' + nv.utils.NaNtoZero(x(getX(d[0],d[1]))) + ',' + nv.utils.NaNtoZero(y(getY(d[0],d[1]))) + ')'
                 });
             // Update points appearance only if "shape" or "size" have changed
-            points.filter(function (d) { return scaleDiff || sizeDiff || getDiffs(d, 'shape', getShape, 'size', getSize); })
+            points.filter(function (d) { return getDiffs(d, 'shape', getShape, 'size', getSize) || scaleDiff || sizeDiff; })
                 .watchTransition(renderWatch, 'scatter points')
                 .attr('d',
                     nv.utils.symbol()


### PR DESCRIPTION
- **Comments** - For implementation decisions and optimisations (Requested by @liquidpele in #1817)
- **Formatting** - Conservative tidying of concerned code for legibility
- ~~**Performance** - Remove duplicate point enter/exit code (credit to @PeterVermont from #1814)~~
- **Fix** - A subtle edge case with invalid caches

The removal of the duplicate code warrants some thorough testing, it does appear to be unnecessary but it's possible it was there for a reason. The change passes all unit tests and at a glance everything seems ok. I'm gradually going through the examples in painful detail, (other testers are welcome).