### PR TITLE
Fixes Issue #330 - Scatter chart error when multiple points have same value

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -222,13 +222,12 @@ nv.models.scatter = function() {
                                 .map(function(point, pointIndex) {
                                     // *Adding noise to make duplicates very unlikely
                                     // *Injecting series and point index for reference
-                                    /* *Adding a 'jitter' to the points, because there's an issue in d3.geom.voronoi.
-                                     */
+                                    // *Adding a 'jitter' to the points, because there's an issue in d3.geom.voronoi.
                                     var pX = getX(point,pointIndex);
                                     var pY = getY(point,pointIndex);
 
-                                    return [nv.utils.NaNtoZero(x(pX)),
-                                            nv.utils.NaNtoZero(y(pY)),
+                                    return [nv.utils.NaNtoZero(x(pX)) + Math.random() * 1e-4,
+                                            nv.utils.NaNtoZero(y(pY)) + Math.random() * 1e-4,
                                         groupIndex,
                                         pointIndex, point];
                                 })
@@ -257,7 +256,7 @@ nv.models.scatter = function() {
                     ]);
 
                     // delete duplicates from vertices - essential assumption for d3.geom.voronoi
-                    var epsilon = 1e-6; // d3 uses 1e-6 to determine equivalence.
+                    var epsilon = 1e-4; // Uses 1e-4 to determine equivalence.
                     vertices = vertices.sort(function(a,b){return ((a[0] - b[0]) || (a[1] - b[1]))});
                     for (var i = 0; i < vertices.length - 1; ) {
                         if ((Math.abs(vertices[i][0] - vertices[i+1][0]) < epsilon) &&

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -227,10 +227,10 @@ nv.models.scatter = function() {
                                     var pX = getX(point,pointIndex);
                                     var pY = getY(point,pointIndex);
 
-                                    return [nv.utils.NaNtoZero(x(pX))+ Math.random() * 1e-4,
-                                            nv.utils.NaNtoZero(y(pY))+ Math.random() * 1e-4,
+                                    return [nv.utils.NaNtoZero(x(pX)),
+                                            nv.utils.NaNtoZero(y(pY)),
                                         groupIndex,
-                                        pointIndex, point]; //temp hack to add noise until I think of a better way so there are no duplicates
+                                        pointIndex, point];
                                 })
                                 .filter(function(pointArray, pointIndex) {
                                     return pointActive(pointArray[4], pointIndex); // Issue #237.. move filter to after map, so pointIndex is correct!
@@ -255,6 +255,18 @@ nv.models.scatter = function() {
                         [width + 10,height + 10],
                         [width + 10,-10]
                     ]);
+
+                    // delete duplicates from vertices - essential assumption for d3.geom.voronoi
+                    var epsilon = 1e-6; // d3 uses 1e-6 to determine equivalence.
+                    vertices = vertices.sort(function(a,b){return ((a[0] - b[0]) || (a[1] - b[1]))});
+                    for (var i = 0; i < vertices.length - 1; ) {
+                        if ((Math.abs(vertices[i][0] - vertices[i+1][0]) < epsilon) &&
+                        (Math.abs(vertices[i][1] - vertices[i+1][1]) < epsilon)) {
+                            vertices.splice(i+1, 1);
+                        } else {
+                            i++;
+                        }
+                    }
 
                     var voronoi = d3.geom.voronoi(vertices).map(function(d, i) {
                         return {


### PR DESCRIPTION
The following pull request takes into consideration that adding a jitter to all the points on a line chart will reduce the chance of overlapping points being sent to voronoi, however it is not 100% going to prevent this from happening.  Randomly errors described in issue #330 still occur.

The following fix keeps the jitter, but in case there are still any duplicates, dedupe them.

