### PR TITLE
Add grunt-cli to package.json for local build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "url": "https://github.com/novus/nvd3",
   "main": "build/nv.d3.js",
   "scripts": {
-    "test": "grunt"
+    "test": "grunt",
+    "build": "grunt"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
   "devDependencies": {
     "es6-promise": "^4.0.3",
     "autoprefixer": "^6.5.0",
+    "grunt-cli": "^1.2.0",
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "~1.0.1",
     "grunt-contrib-copy": "~0.4.1",


### PR DESCRIPTION
Make NVD3 development more build system agnostic. There are many node
build systems, not every project uses the same one, we shouldn't have to
remember which one or need to globaly install it's CLI.

npm adds ./node_modules/.bin to the run $PATH, so we can add grunt-cli
to the local dependencies. Contributors are free to use generic "npm run
build" commands without knowing or remembering grunt.