### PR TITLE
Provide tooltip element to contentGenerator to allow custom tooltips to access this element

### DIFF
--- a/examples/documentation.html
+++ b/examples/documentation.html
@@ -897,7 +897,7 @@ as well as used to print out examples using those example inputs.
         contentGenerator: {
             desc: "For tooltip: Function that generates the tooltip content html.  This replaces the 'tooltipContent' option that was on most charts.  Please note that the data passed this function is usually different depending on the chart, so you'll probably need to console.log() the input object.  Also, the data passed is always a single object now, so previous functions written for the tooltipContent option will have to be adjusted accordingly.",
             default: "See contentGenerator function in tooltip.js",
-            examples: [function(obj) { return JSON.stringify(obj)}],
+            examples: [function(obj, elem) { return JSON.stringify(obj)}],
             example_object: 'chart.tooltip'
         },
         valueFormatter: {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -54,9 +54,10 @@ nv.models.tooltip = function() {
         return d;
     };
 
-    // By default, the tooltip model renders a beautiful table inside a DIV.
-    // You can override this function if a custom tooltip is desired.
-    var contentGenerator = function(d) {
+    // By default, the tooltip model renders a beautiful table inside a DIV, returned as HTML
+    // You can override this function if a custom tooltip is desired. For instance, you could directly manipulate
+    // the DOM by accessing elem and returning false.
+    var contentGenerator = function(d, elem) {
         if (d === null) {
             return '';
         }
@@ -287,8 +288,8 @@ nv.models.tooltip = function() {
         nv.dom.write(function () {
             initTooltip();
             // Generate data and set it into tooltip.
-            // Bonus - If you override contentGenerator and return falsey you can use something like
-            //         React or Knockout to bind the data for your tooltip.
+            // Bonus - If you override contentGenerator and return false, you can use something like
+            //         Angular, React or Knockout to bind the data for your tooltip directly to the DOM.
             var newContent = contentGenerator(data, tooltip.node());
             if (newContent) {
                 tooltip.node().innerHTML = newContent;

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -289,7 +289,7 @@ nv.models.tooltip = function() {
             // Generate data and set it into tooltip.
             // Bonus - If you override contentGenerator and return falsey you can use something like
             //         React or Knockout to bind the data for your tooltip.
-            var newContent = contentGenerator(data);
+            var newContent = contentGenerator(data, tooltip.node());
             if (newContent) {
                 tooltip.node().innerHTML = newContent;
             }


### PR DESCRIPTION
I'm using angular-nvd3, where I absolutely need to use Angulars Data Binding within the tooltip.

For this to work, I needed to manually call $compile() with my html template. For the non Angular people here: $compile creates DOM Elements and adds watchers/event handlers/etc... for Angular. 

Overwriting the contentGenerator() method only allows you to return a string (basically HTML), while the comments on the method clearly say:
```javascript
            initTooltip();
            // Generate data and set it into tooltip.
            // Bonus - If you override contentGenerator and return falsey you can use something like
            //         React or Knockout to bind the data for your tooltip.
            var newContent = contentGenerator(data);
            if (newContent) {
                tooltip.node().innerHTML = newContent;
            }
```

I wonder why it says here that you can return false...

I believe that my PR, where I only change the call from ``var newContent = contentGenerator(data);`` to ``var newContent = contentGenerator(data, tooltip.node());``, does not break any existing calls, but provides the ability to also directly manipulate the DOM.

For instance, my contentGenerator method in AngularJS (use with care, no guarantees) would look like this:
```javascript
        var renderTooltip = function(d, el) {
            $scope.$apply(function() {
                // remember the current index
                $scope.selectedTooltipIndex = d.index;
            });

            // check if there are already childnodes
            if (el.childNodes.length != 0) {
                // this is apparently not the first time, no need to do anything here
                return false;
            }

            // render a html-compile with the current selected tooltip index
            var html = '<div html-compile="widget.config.tooltipTemplate" ' +
                ' html-compile-scope="barData[0].values[selectedTooltipIndex]" html-compile-scope-bind="obj"></div>';

            var newElem = $(html);
            $compile(newElem)($scope);

            el = $(el);
            el.append(newElem.get(0));
            $scope.$apply();

            return false;
        };
```