### PR TITLE
[pie-chart] Fix label overlap

### DIFF
--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -338,6 +338,39 @@ nv.models.pie = function() {
                         }
                         return label;
                     })
+                    .each(function (d, i) {
+                      var bb = this.getBBox(),
+                        center = labelsArc[i].centroid(d);
+                      console.log({center: center})
+                      console.log({bb: bb})
+                      var topLeft = {
+                          x : center[0] + bb.x,
+                          y : center[1] + bb.y
+                      };
+
+                      var topRight = {
+                          x : topLeft.x + bb.width,
+                          y : topLeft.y
+                      };
+
+                      var bottomLeft = {
+                          x : topLeft.x,
+                          y : topLeft.y + bb.height
+                      };
+
+                      var bottomRight = {
+                          x : topLeft.x + bb.width,
+                          y : topLeft.y + bb.height
+                      };
+
+                      d.visible = nv.utils.pointIsInArc(topLeft, d, arc) &&
+                        nv.utils.pointIsInArc(topRight, d, arc) &&
+                        nv.utils.pointIsInArc(bottomLeft, d, arc) &&
+                        nv.utils.pointIsInArc(bottomRight, d, arc);
+                    })
+                    .style('display', function (d) {
+                      return d.visible ? null : 'none';
+                    })
                 ;
             }
 

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -341,8 +341,6 @@ nv.models.pie = function() {
                     .each(function (d, i) {
                       var bb = this.getBBox(),
                         center = labelsArc[i].centroid(d);
-                      console.log({center: center})
-                      console.log({bb: bb})
                       var topLeft = {
                           x : center[0] + bb.x,
                           y : center[1] + bb.y

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -18,6 +18,7 @@ nv.models.pie = function() {
         , labelsOutside = false
         , labelType = "key"
         , labelThreshold = .02 //if slice percentage is under this, don't show label
+        , hideOverlapLabels = false //Hide labels that don't fit in slice
         , donut = false
         , title = false
         , growOnHover = true
@@ -338,39 +339,45 @@ nv.models.pie = function() {
                         }
                         return label;
                     })
-                    .each(function (d, i) {
-                        if (!this.getBBox) return;
-                        var bb = this.getBBox(),
-                        center = labelsArc[i].centroid(d);
-                        var topLeft = {
-                          x : center[0] + bb.x,
-                          y : center[1] + bb.y
-                        };
-
-                        var topRight = {
-                          x : topLeft.x + bb.width,
-                          y : topLeft.y
-                        };
-
-                        var bottomLeft = {
-                          x : topLeft.x,
-                          y : topLeft.y + bb.height
-                        };
-
-                        var bottomRight = {
-                          x : topLeft.x + bb.width,
-                          y : topLeft.y + bb.height
-                        };
-
-                        d.visible = nv.utils.pointIsInArc(topLeft, d, arc) &&
-                        nv.utils.pointIsInArc(topRight, d, arc) &&
-                        nv.utils.pointIsInArc(bottomLeft, d, arc) &&
-                        nv.utils.pointIsInArc(bottomRight, d, arc);
-                    })
-                    .style('display', function (d) {
-                        return d.visible ? null : 'none';
-                    })
                 ;
+
+                if (hideOverlapLabels) {
+                    pieLabels
+                        .each(function (d, i) {
+                            if (!this.getBBox) return;
+                            var bb = this.getBBox(),
+                            center = labelsArc[i].centroid(d);
+                            var topLeft = {
+                              x : center[0] + bb.x,
+                              y : center[1] + bb.y
+                            };
+
+                            var topRight = {
+                              x : topLeft.x + bb.width,
+                              y : topLeft.y
+                            };
+
+                            var bottomLeft = {
+                              x : topLeft.x,
+                              y : topLeft.y + bb.height
+                            };
+
+                            var bottomRight = {
+                              x : topLeft.x + bb.width,
+                              y : topLeft.y + bb.height
+                            };
+
+                            d.visible = nv.utils.pointIsInArc(topLeft, d, arc) &&
+                            nv.utils.pointIsInArc(topRight, d, arc) &&
+                            nv.utils.pointIsInArc(bottomLeft, d, arc) &&
+                            nv.utils.pointIsInArc(bottomRight, d, arc);
+                        })
+                        .style('display', function (d) {
+                            return d.visible ? null : 'none';
+                        })
+                    ;
+                }
+
             }
 
 
@@ -412,6 +419,7 @@ nv.models.pie = function() {
         title:      {get: function(){return title;}, set: function(_){title=_;}},
         titleOffset:    {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         labelThreshold: {get: function(){return labelThreshold;}, set: function(_){labelThreshold=_;}},
+        hideOverlapLabels: {get: function(){return hideOverlapLabels;}, set: function(_){hideOverlapLabels=_;}},
         valueFormat:    {get: function(){return valueFormat;}, set: function(_){valueFormat=_;}},
         x:          {get: function(){return getX;}, set: function(_){getX=_;}},
         id:         {get: function(){return id;}, set: function(_){id=_;}},

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -339,35 +339,36 @@ nv.models.pie = function() {
                         return label;
                     })
                     .each(function (d, i) {
-                      var bb = this.getBBox(),
+                        if (!this.getBBox) return;
+                        var bb = this.getBBox(),
                         center = labelsArc[i].centroid(d);
-                      var topLeft = {
+                        var topLeft = {
                           x : center[0] + bb.x,
                           y : center[1] + bb.y
-                      };
+                        };
 
-                      var topRight = {
+                        var topRight = {
                           x : topLeft.x + bb.width,
                           y : topLeft.y
-                      };
+                        };
 
-                      var bottomLeft = {
+                        var bottomLeft = {
                           x : topLeft.x,
                           y : topLeft.y + bb.height
-                      };
+                        };
 
-                      var bottomRight = {
+                        var bottomRight = {
                           x : topLeft.x + bb.width,
                           y : topLeft.y + bb.height
-                      };
+                        };
 
-                      d.visible = nv.utils.pointIsInArc(topLeft, d, arc) &&
+                        d.visible = nv.utils.pointIsInArc(topLeft, d, arc) &&
                         nv.utils.pointIsInArc(topRight, d, arc) &&
                         nv.utils.pointIsInArc(bottomLeft, d, arc) &&
                         nv.utils.pointIsInArc(bottomRight, d, arc);
                     })
                     .style('display', function (d) {
-                      return d.visible ? null : 'none';
+                        return d.visible ? null : 'none';
                     })
                 ;
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -710,3 +710,24 @@ nv.utils.arrayEquals = function (array1, array2) {
     }
     return true;
 };
+
+/*
+ Check if a point within an arc
+ */
+nv.utils.pointIsInArc = function(pt, ptData, d3Arc) {
+    // Center of the arc is assumed to be 0,0
+    // (pt.x, pt.y) are assumed to be relative to the center
+    var r1 = d3Arc.innerRadius()(ptData), // Note: Using the innerRadius
+      r2 = d3Arc.outerRadius()(ptData),
+      theta1 = d3Arc.startAngle()(ptData),
+      theta2 = d3Arc.endAngle()(ptData);
+
+    var dist = pt.x * pt.x + pt.y * pt.y,
+      angle = Math.atan2(pt.x, -pt.y); // Note: different coordinate system.
+
+    angle = (angle < 0) ? (angle + Math.PI * 2) : angle;
+
+    return (r1 * r1 <= dist) && (dist <= r2 * r2) &&
+      (theta1 <= angle) && (angle <= theta2);
+};
+


### PR DESCRIPTION
Not to display overlapping labels

Before
![labels-overlap](https://cloud.githubusercontent.com/assets/2973998/22974116/f773e280-f391-11e6-87df-671b1e2e7837.png)

After
![no-overlap](https://cloud.githubusercontent.com/assets/2973998/22974123/fe28b88a-f391-11e6-839a-10f885c4f996.png)

Credits
http://stackoverflow.com/a/19801529/2697673