### PR TITLE
modify indexify to divide by v and not by v+1

### DIFF
--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -563,10 +563,8 @@ nv.models.cumulativeLineChart = function() {
             }
             var v = indexifyYGetter(indexValue, idx);
 
-            //TODO: implement check below, and disable series if series loses 100% or more cause divide by 0 issue
-            if (v < -.95 && !noErrorCheck) {
-                //if a series loses more than 100%, calculations fail.. anything close can cause major distortion (but is mathematically correct till it hits 100)
-
+            // avoid divide by zero
+            if (Math.abs(v) < 0.00001 && !noErrorCheck) {
                 line.tempDisabled = true;
                 return line;
             }
@@ -574,7 +572,7 @@ nv.models.cumulativeLineChart = function() {
             line.tempDisabled = false;
 
             line.values = line.values.map(function(point, pointIndex) {
-                point.display = {'y': (indexifyYGetter(point, pointIndex) - v) / (1 + v) };
+                point.display = {'y': (indexifyYGetter(point, pointIndex) - v) / v };
                 return point;
             });
 

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -131,7 +131,7 @@ nv.models.scatter = function() {
             });
 
             // Setup Scales
-            var logScale = chart.yScale().name === d3.scale.log().name ? true : false;
+            var logScale = (typeof(chart.yScale().base) === "function"); // Only log scale has a method "base()"
             // remap and flatten the data for use in calculating the scales' domains
             var seriesData = (xDomain && yDomain && sizeDomain) ? [] : // if we know xDomain and yDomain and sizeDomain, no need to calculate.... if Size is constant remember to set sizeDomain to speed up performance
                 d3.merge(

--- a/test/mocha/cumulative-line.coffee
+++ b/test/mocha/cumulative-line.coffee
@@ -3,7 +3,7 @@ describe 'NVD3', ->
         sampleData1 = [
             key: 'Series 1'
             values: [
-                [-1,-1]
+                [0.000001, 0.000001]
                 [0,0]
                 [1,1]
                 [2,2]


### PR DESCRIPTION
The cumulativeChart is actually an index chart, see [http://mbostock.github.io/protovis/ex/index-chart.html](http://mbostock.github.io/protovis/ex/index-chart.html) (I think, the name should be changed some day).

However, the first thing should be to correct the math: the `y` axis shows the percentage of `y_i` relative to the index value `v`. So the right formula is `(y_i - v)/v` (as also used in Mike Bostocks code) and not `(y_i - v)/(1 + v)`