### PR TITLE
Restore pre #1554 behaviour of bars that go down to 0 by default

### DIFF
--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -213,8 +213,12 @@ nv.models.multiChart = function() {
                 if (extraValue1BarStacked.length > 0)
                     extraValue1BarStacked = extraValue1BarStacked.reduce(function(a,b){
                         return a.map(function(aVal,i){return {x: aVal.x, y: aVal.y + b[i].y}})
-                    }).concat([{x:0, y:0}]);
+                    });
             }
+            if (dataBars1.length) {
+                extraValue1BarStacked.push({x:0, y:0});
+            }
+            
             var extraValue2BarStacked = [];
             if (bars2.stacked() && dataBars2.length) {
                 var extraValue2BarStacked = dataBars2.filter(function(d){return !d.disabled}).map(function(a){return a.values});
@@ -222,7 +226,10 @@ nv.models.multiChart = function() {
                 if (extraValue2BarStacked.length > 0)
                     extraValue2BarStacked = extraValue2BarStacked.reduce(function(a,b){
                         return a.map(function(aVal,i){return {x: aVal.x, y: aVal.y + b[i].y}})
-                    }).concat([{x:0, y:0}]);
+                    });
+            }
+            if (dataBars2.length) {
+                extraValue2BarStacked.push({x:0, y:0});
             }
             
             yScale1 .domain(yDomain1 || d3.extent(d3.merge(series1).concat(extraValue1BarStacked), function(d) { return d.y } ))


### PR DESCRIPTION
This commit introduced a subtle regression:
https://github.com/novus/nvd3/commit/9b75644ebc5c15caa2bb803e8d5612e1463caf5b#diff-b5254de5addcaf88c0900e46af95e3d7

Before it, `{x:0, y:0}` would get added to the `extraValue` only if `dataBars1.length`. The change made non-stacked bar charts behave differently.