### PR TITLE
Code Changes for Furious Check Box Issues In IE - furiousLegend.js & legend.js

### DIFF
--- a/src/models/furiousLegend.js
+++ b/src/models/furiousLegend.js
@@ -63,10 +63,24 @@ nv.models.furiousLegend = function() {
 
                 seriesShape = series.select('rect');
 
-                seriesEnter.append('g')
+//                 seriesEnter.append('g')
+//                     .attr('class', 'nv-check-box')
+//                     .property('innerHTML','<path d="M0.5,5 L22.5,5 L22.5,26.5 L0.5,26.5 L0.5,5 Z" class="nv-box"></path><path d="M5.5,12.8618467 L11.9185089,19.2803556 L31,0.198864511" class="nv-check"></path>')
+//                     .attr('transform', 'translate(-10,-8)scale(0.5)');
+                
+                var seriesFuriousBox = seriesEnter.append('g')
                     .attr('class', 'nv-check-box')
-                    .property('innerHTML','<path d="M0.5,5 L22.5,5 L22.5,26.5 L0.5,26.5 L0.5,5 Z" class="nv-box"></path><path d="M5.5,12.8618467 L11.9185089,19.2803556 L31,0.198864511" class="nv-check"></path>')
                     .attr('transform', 'translate(-10,-8)scale(0.5)');
+                
+                    // For Box
+                    seriesFuriousBox.append('path')
+                    .attr('d','M0.5,5 L22.5,5 L22.5,26.5 L0.5,26.5 L0.5,5 Z')
+                    .attr('class','nv-box');
+                
+                    // For Check
+                    seriesFuriousBox.append('path')
+                    .attr('d','M5.5,12.8618467 L11.9185089,19.2803556 L31,0.198864511')
+                    .attr('class','nv-check'); 
 
                 var seriesCheckbox = series.select('.nv-check-box');
 

--- a/src/models/legend.js
+++ b/src/models/legend.js
@@ -75,10 +75,24 @@ nv.models.legend = function() {
                     .attr('ry', 3);
                 seriesShape = series.select('.nv-legend-symbol');
 
-                seriesEnter.append('g')
+//                 seriesEnter.append('g')
+//                     .attr('class', 'nv-check-box')
+//                     .property('innerHTML','<path d="M0.5,5 L22.5,5 L22.5,26.5 L0.5,26.5 L0.5,5 Z" class="nv-box"></path><path d="M5.5,12.8618467 L11.9185089,19.2803556 L31,0.198864511" class="nv-check"></path>')
+//                     .attr('transform', 'translate(-10,-8)scale(0.5)');
+                
+                var seriesFuriousBox = seriesEnter.append('g')
                     .attr('class', 'nv-check-box')
-                    .property('innerHTML','<path d="M0.5,5 L22.5,5 L22.5,26.5 L0.5,26.5 L0.5,5 Z" class="nv-box"></path><path d="M5.5,12.8618467 L11.9185089,19.2803556 L31,0.198864511" class="nv-check"></path>')
                     .attr('transform', 'translate(-10,-8)scale(0.5)');
+                
+                    // For Box
+                    seriesFuriousBox.append('path')
+                    .attr('d','M0.5,5 L22.5,5 L22.5,26.5 L0.5,26.5 L0.5,5 Z')
+                    .attr('class','nv-box');
+                
+                    // For Check
+                    seriesFuriousBox.append('path')
+                    .attr('d','M5.5,12.8618467 L11.9185089,19.2803556 L31,0.198864511')
+                    .attr('class','nv-check'); 
 
                 var seriesCheckbox = series.select('.nv-check-box');
 


### PR DESCRIPTION
Hi Guys,

I fixed the Furious Legend Issues in IE Browser. Not tested in Safari. I hope it will work in safari also.

`.property('innerHTML')` - **InnerHTML** not working in IE. That's why path '**nv-box**' and '**nv-check**' elements are not rendering inside g '**nv-check-box**' element.

So, I updated the code like below.

**Current Code:**

```
seriesEnter.append('g')
        .attr('class', 'nv-check-box')
        .property('innerHTML','<path d="M0.5,5 L22.5,5 L22.5,26.5 L0.5,26.5 L0.5,5 Z" class="nv-box"></path><path d="M5.5,12.8618467 L11.9185089,19.2803556 L31,0.198864511" class="nv-check"></path>')
        .attr('transform', 'translate(-10,-8)scale(0.5)');
```
**Update Code:**

```
var seriesFuriousBox = seriesEnter.append('g')
   .attr('class', 'nv-check-box')
   .attr('transform', 'translate(-10,-8)scale(0.5)');

   // For Box
   seriesFuriousBox.append('path')
   .attr('d','M0.5,5 L22.5,5 L22.5,26.5 L0.5,26.5 L0.5,5 Z')
   .attr('class','nv-box');
   
   // For Check
   seriesFuriousBox.append('path')
   .attr('d','M5.5,12.8618467 L11.9185089,19.2803556 L31,0.198864511')
   .attr('class','nv-check'); 
```

Thanks,
Gowri Shankar