### PR TITLE
fixed check for log scale

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -131,7 +131,7 @@ nv.models.scatter = function() {
             });
 
             // Setup Scales
-            var logScale = chart.yScale().name === d3.scale.log().name ? true : false;
+            var logScale = (typeof(chart.yScale().base) === "function"); // Only log scale has a method "base()"
             // remap and flatten the data for use in calculating the scales' domains
             var seriesData = (xDomain && yDomain && sizeDomain) ? [] : // if we know xDomain and yDomain and sizeDomain, no need to calculate.... if Size is constant remember to set sizeDomain to speed up performance
                 d3.merge(


### PR DESCRIPTION
In https://github.com/d3/d3-scale the only scale that has a `base() `method is the log scale.
So checking whether `chart.yScale()base` is a function or not should differentiate between log scale case and any other case.