### PR TITLE
added xScale option for multiChart graph

### DIFF
--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -538,6 +538,7 @@ nv.models.multiChart = function() {
         width:      {get: function(){return width;}, set: function(_){width=_;}},
         height:     {get: function(){return height;}, set: function(_){height=_;}},
         showLegend: {get: function(){return showLegend;}, set: function(_){showLegend=_;}},
+        xScale: {get: function(){return x;}, set: function(_){ x = _; xAxis.scale(x); }},
         yDomain1:      {get: function(){return yDomain1;}, set: function(_){yDomain1=_;}},
         yDomain2:    {get: function(){return yDomain2;}, set: function(_){yDomain2=_;}},
         noData:    {get: function(){return noData;}, set: function(_){noData=_;}},


### PR DESCRIPTION
Added new option `xScale` to multiChart graph solvind the issue 

```
chart = nv.models.multiChart()
      .margin({ right: 23, top: 12, left: 60, bottom: 75 })
      .showLegend(false)
      .xScale(d3.time.scale.utc())
```

This may close #814 