### PR TITLE
Fixed bug where tooltip would be inserted outside Body

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -265,7 +265,7 @@ nv.models.tooltip = function() {
             // Create new tooltip div if it doesn't exist on DOM.
 
             var data = [1];
-            tooltip = d3.select(document.body).select('#'+id).data(data);
+            tooltip = d3.select(document.body).selectAll('#'+id).data(data);
 
             tooltip.enter().append('div')
                    .attr("class", "nvtooltip " + (classes ? classes : "xy-tooltip"))


### PR DESCRIPTION
The old code:
 tooltip = d3.select(document.body).select('#'+id).data(data);

Added the tooltip div outside the Body tag, which then led to translation tools not finding the tool tip text.
This is also not valid HTML

By using:
 tooltip = d3.select(document.body).selectAll('#'+id).data(data);

The tooltip div is once again inserted inside the body tag, where it should be.