### PR TITLE
added `title()` option for all chart types

### DIFF
--- a/src/models/boxPlot.js
+++ b/src/models/boxPlot.js
@@ -22,6 +22,8 @@ nv.models.boxPlot = function() {
         getOlValue = function(d, i, j) { return d },
         getOlLabel = function(d, i, j) { return d },
         getOlColor = function(d, i, j) { return undefined },
+        title = false,
+        titleOffset = {top: 0, left: 0},
         color = nv.utils.defaultColor(),
         container = null,
         xDomain, xRange,
@@ -100,6 +102,21 @@ nv.models.boxPlot = function() {
                     return 'translate(' + (xScale(getX(d,i)) + xScale.rangeBand() * 0.05) + ', 0)';
                 });
             boxplots.exit().remove();
+
+            var g_box = wrapEnter.append('g').attr('class', 'nv-box');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_box
+                    .append("text")
+                    .attr('class', 'nv-box-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             // ----- add the SVG elements for each boxPlot -----
 
@@ -292,6 +309,8 @@ nv.models.boxPlot = function() {
         yDomain: {get: function(){return yDomain;}, set: function(_){yDomain=_;}},
         xRange:  {get: function(){return xRange;}, set: function(_){xRange=_;}},
         yRange:  {get: function(){return yRange;}, set: function(_){yRange=_;}},
+        title:       {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset: {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         id:          {get: function(){return id;}, set: function(_){id=_;}},
         // rectClass: {get: function(){return rectClass;}, set: function(_){rectClass=_;}},
         y: {

--- a/src/models/bullet.js
+++ b/src/models/bullet.js
@@ -24,6 +24,8 @@ nv.models.bullet = function() {
         , forceX = [0] // List of numbers to Force into the X scale (ie. 0, or a max / min, etc.)
         , width = 380
         , height = 30
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , container = null
         , tickFormat = null
         , color = nv.utils.getColor(['#1f77b4'])
@@ -94,6 +96,7 @@ nv.models.bullet = function() {
             var wrapEnter = wrap.enter().append('g').attr('class', 'nvd3 nv-wrap nv-bullet');
             var gEnter = wrapEnter.append('g');
             var g = wrap.select('g');
+            var g_bullet = container.append('g').attr('class', 'nv-bullet');
 
             for(var i=0,il=rangez.length; i<il; i++){
                 var rangeClassNames = 'nv-range nv-range'+i;
@@ -106,6 +109,20 @@ nv.models.bullet = function() {
             gEnter.append('rect').attr('class', 'nv-measure');
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_bullet
+                    .append("text")
+                    .attr('class', 'nv-bullet-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             var w0 = function(d) { return Math.abs(x0(d) - x0(0)) }, // TODO: could optimize by precalculating x0(0) and x1(0)
                 w1 = function(d) { return Math.abs(x1(d) - x1(0)) };
@@ -288,6 +305,8 @@ nv.models.bullet = function() {
         height:    {get: function(){return height;}, set: function(_){height=_;}},
         tickFormat:    {get: function(){return tickFormat;}, set: function(_){tickFormat=_;}},
         duration:    {get: function(){return duration;}, set: function(_){duration=_;}},
+        title:       {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset: {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
 
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){

--- a/src/models/candlestickBar.js
+++ b/src/models/candlestickBar.js
@@ -25,6 +25,8 @@ nv.models.candlestickBar = function() {
         , clipEdge = true
         , color = nv.utils.defaultColor()
         , interactive = false
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , xDomain
         , yDomain
         , xRange
@@ -92,6 +94,21 @@ nv.models.candlestickBar = function() {
                         id: id
                     });
                 });
+
+            var g_bar = wrapEnter.append('g').attr('class', 'nv-bar');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_bar
+                    .append("text")
+                    .attr('class', 'nv-bar-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             defsEnter.append('clipPath')
                 .attr('id', 'nv-chart-clip-path-' + id)
@@ -201,7 +218,8 @@ nv.models.candlestickBar = function() {
         clipEdge: {get: function(){return clipEdge;}, set: function(_){clipEdge=_;}},
         id:       {get: function(){return id;}, set: function(_){id=_;}},
         interactive: {get: function(){return interactive;}, set: function(_){interactive=_;}},
-
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         x:     {get: function(){return getX;}, set: function(_){getX=_;}},
         y:     {get: function(){return getY;}, set: function(_){getY=_;}},
         open:  {get: function(){return getOpen();}, set: function(_){getOpen=_;}},

--- a/src/models/discreteBar.js
+++ b/src/models/discreteBar.js
@@ -21,6 +21,8 @@ nv.models.discreteBar = function() {
         , valueFormat = d3.format(',.2f')
         , xDomain
         , yDomain
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , xRange
         , yRange
         , dispatch = d3.dispatch('chartClick', 'elementClick', 'elementDblClick', 'elementMouseover', 'elementMouseout', 'elementMousemove', 'renderEnd')
@@ -77,9 +79,23 @@ nv.models.discreteBar = function() {
             var wrapEnter = wrap.enter().append('g').attr('class', 'nvd3 nv-wrap nv-discretebar');
             var gEnter = wrapEnter.append('g');
             var g = wrap.select('g');
+            var g_bar = wrapEnter.append('g').attr('class', 'nv-bar');
 
             gEnter.append('g').attr('class', 'nv-groups');
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_bar
+                    .append("text")
+                    .attr('class', 'nv-bar-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             //TODO: by definition, the discrete bar should not have multiple groups, will modify/remove later
             var groups = wrap.select('.nv-groups').selectAll('.nv-group')
@@ -228,6 +244,8 @@ nv.models.discreteBar = function() {
         yDomain: {get: function(){return yDomain;}, set: function(_){yDomain=_;}},
         xRange:  {get: function(){return xRange;}, set: function(_){xRange=_;}},
         yRange:  {get: function(){return yRange;}, set: function(_){yRange=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         valueFormat:    {get: function(){return valueFormat;}, set: function(_){valueFormat=_;}},
         id:          {get: function(){return id;}, set: function(_){id=_;}},
         rectClass: {get: function(){return rectClass;}, set: function(_){rectClass=_;}},

--- a/src/models/forceDirectedGraph.js
+++ b/src/models/forceDirectedGraph.js
@@ -12,6 +12,8 @@ nv.models.forceDirectedGraph = function() {
         , color = nv.utils.getColor(['#000'])
         , tooltip      = nv.models.tooltip()
         , noData = null
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         // Force directed graph specific parameters [default values]
         , linkStrength = 0.1
         , friction = 0.9
@@ -57,6 +59,21 @@ nv.models.forceDirectedGraph = function() {
               container.selectAll('.nv-noData').remove();
           }
           container.selectAll('*').remove();
+
+          var g_force = container.append('g').attr('class', 'nv-force');
+
+          // add a title if specified
+          if (title) {
+              var plotTitle = g_force
+                  .append("text")
+                  .attr('class', 'nv-force-title')
+                  .style("text-anchor", "middle")
+                  .style("font-size", "150%")
+                  .text(function (d) { return title; })
+                  .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',40)'; }) // center title
+                  .attr('dx',titleOffset.left)
+                  .attr('dy',titleOffset.top)
+          }
 
           // Collect names of all fields in the nodes
           var nodeFieldSet = new Set();
@@ -150,6 +167,8 @@ nv.models.forceDirectedGraph = function() {
         // simple options, just get/set the necessary values
         width:     {get: function(){return width;}, set: function(_){width=_;}},
         height:    {get: function(){return height;}, set: function(_){height=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
 
         // Force directed graph specific parameters
         linkStrength:{get: function(){return linkStrength;}, set: function(_){linkStrength=_;}},

--- a/src/models/historicalBar.js
+++ b/src/models/historicalBar.js
@@ -22,6 +22,8 @@ nv.models.historicalBar = function() {
         , color = nv.utils.defaultColor()
         , xDomain
         , yDomain
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , xRange
         , yRange
         , dispatch = d3.dispatch('chartClick', 'elementClick', 'elementDblClick', 'elementMouseover', 'elementMouseout', 'elementMousemove', 'renderEnd')
@@ -68,9 +70,23 @@ nv.models.historicalBar = function() {
             var defsEnter = wrapEnter.append('defs');
             var gEnter = wrapEnter.append('g');
             var g = wrap.select('g');
+            var g_bar = wrapEnter.append('g').attr('class', 'nv-bar');
 
             gEnter.append('g').attr('class', 'nv-bars');
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_bar
+                    .append("text")
+                    .attr('class', 'nv-bar-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             container
                 .on('click', function(d,i) {
@@ -212,6 +228,8 @@ nv.models.historicalBar = function() {
         yDomain: {get: function(){return yDomain;}, set: function(_){yDomain=_;}},
         xRange:  {get: function(){return xRange;}, set: function(_){xRange=_;}},
         yRange:  {get: function(){return yRange;}, set: function(_){yRange=_;}},
+        title:       {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset: {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         clipEdge:    {get: function(){return clipEdge;}, set: function(_){clipEdge=_;}},
         id:          {get: function(){return id;}, set: function(_){id=_;}},
         interactive: {get: function(){return interactive;}, set: function(_){interactive=_;}},

--- a/src/models/line.js
+++ b/src/models/line.js
@@ -21,6 +21,8 @@ nv.models.line = function() {
         , clipEdge = false // if true, masks lines within x and y scale
         , x //can be accessed via chart.xScale()
         , y //can be accessed via chart.yScale()
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , interpolate = "linear" // controls the line interpolation
         , duration = 250
         , dispatch = d3.dispatch('elementClick', 'elementMouseover', 'elementMouseout', 'renderEnd')
@@ -67,11 +69,25 @@ nv.models.line = function() {
             var defsEnter = wrapEnter.append('defs');
             var gEnter = wrapEnter.append('g');
             var g = wrap.select('g');
+            var g_line = wrapEnter.append('g').attr('class', 'nv-line');
 
             gEnter.append('g').attr('class', 'nv-groups');
             gEnter.append('g').attr('class', 'nv-scatterWrap');
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_line
+                    .append("text")
+                    .attr('class', 'nv-line-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             scatter
                 .width(availableWidth)
@@ -192,6 +208,8 @@ nv.models.line = function() {
         defined: {get: function(){return defined;}, set: function(_){defined=_;}},
         interpolate:      {get: function(){return interpolate;}, set: function(_){interpolate=_;}},
         clipEdge:    {get: function(){return clipEdge;}, set: function(_){clipEdge=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
 
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -21,6 +21,8 @@ nv.models.multiBar = function() {
         , stackOffset = 'zero' // options include 'silhouette', 'wiggle', 'expand', 'zero', or a custom function
         , color = nv.utils.defaultColor()
         , hideable = false
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , barColor = null // adding the ability to set the color for each rather than the whole group
         , disabled // used in conjunction with barColor to communicate from multiBarHorizontalChart what series are disabled
         , duration = 500
@@ -180,6 +182,21 @@ nv.models.multiBar = function() {
                 .attr('height', availableHeight);
 
             g.attr('clip-path', clipEdge ? 'url(#nv-edge-clip-' + id + ')' : '');
+
+            var g_bar = wrapEnter.append('g').attr('class', 'nv-bar');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_bar
+                    .append("text")
+                    .attr('class', 'nv-bar-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             var groups = wrap.select('.nv-groups').selectAll('.nv-group')
                 .data(function(d) { return d }, function(d,i) { return i });
@@ -409,6 +426,8 @@ nv.models.multiBar = function() {
         hideable:    {get: function(){return hideable;}, set: function(_){hideable=_;}},
         groupSpacing:{get: function(){return groupSpacing;}, set: function(_){groupSpacing=_;}},
         fillOpacity: {get: function(){return fillOpacity;}, set: function(_){fillOpacity=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
 
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -183,7 +183,7 @@ nv.models.multiBar = function() {
 
             g.attr('clip-path', clipEdge ? 'url(#nv-edge-clip-' + id + ')' : '');
 
-            var g_bar = wrapEnter.append('g').attr('class', 'nv-bar');
+            var g_bar = wrapEnter.append('g').attr('class', 'nv-title');
 
             // add a title if specified
             if (title) {

--- a/src/models/multiBarHorizontal.js
+++ b/src/models/multiBarHorizontal.js
@@ -119,7 +119,7 @@ nv.models.multiBarHorizontal = function() {
             gEnter.append('g').attr('class', 'nv-groups');
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
-            var g_bar = wrapEnter.append('g').attr('class', 'nv-bar');
+            var g_bar = wrapEnter.append('g').attr('class', 'nv-title');
 
             // add a title if specified
             if (title) {

--- a/src/models/multiBarHorizontal.js
+++ b/src/models/multiBarHorizontal.js
@@ -20,6 +20,8 @@ nv.models.multiBarHorizontal = function() {
         , color = nv.utils.defaultColor()
         , barColor = null // adding the ability to set the color for each rather than the whole group
         , disabled // used in conjunction with barColor to communicate from multiBarHorizontalChart what series are disabled
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , stacked = false
         , showValues = false
         , showBarLabels = false
@@ -116,6 +118,22 @@ nv.models.multiBarHorizontal = function() {
 
             gEnter.append('g').attr('class', 'nv-groups');
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+            var g_bar = wrapEnter.append('g').attr('class', 'nv-bar');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_bar
+                    .append("text")
+                    .attr('class', 'nv-bar-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
+
 
             var groups = wrap.select('.nv-groups').selectAll('.nv-group')
                 .data(function(d) { return d }, function(d,i) { return i });
@@ -328,6 +346,8 @@ nv.models.multiBarHorizontal = function() {
         forceY:  {get: function(){return forceY;}, set: function(_){forceY=_;}},
         stacked: {get: function(){return stacked;}, set: function(_){stacked=_;}},
         showValues: {get: function(){return showValues;}, set: function(_){showValues=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         // this shows the group name, seems pointless?
         //showBarLabels:    {get: function(){return showBarLabels;}, set: function(_){showBarLabels=_;}},
         disabled:     {get: function(){return disabled;}, set: function(_){disabled=_;}},

--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -16,6 +16,8 @@ nv.models.multiChart = function() {
         yDomain2,
         getX = function(d) { return d.x },
         getY = function(d) { return d.y},
+        title = false,
+        titleOffset = {top: 0, left: 0},
         interpolate = 'linear',
         useVoronoi = true,
         interactiveLayer = nv.interactiveGuideline(),
@@ -116,6 +118,21 @@ nv.models.multiChart = function() {
             gEnter.append('g').attr('class', 'lines2Wrap');
             gEnter.append('g').attr('class', 'legendWrap');
             gEnter.append('g').attr('class', 'nv-interactive');
+
+            var g_multi = gEnter.append('g').attr('class', 'nv-multi');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_multi
+                    .append("text")
+                    .attr('class', 'nv-multi-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             var g = wrap.select('g');
 
@@ -543,6 +560,8 @@ nv.models.multiChart = function() {
         noData:    {get: function(){return noData;}, set: function(_){noData=_;}},
         interpolate:    {get: function(){return interpolate;}, set: function(_){interpolate=_;}},
         legendRightAxisHint:    {get: function(){return legendRightAxisHint;}, set: function(_){legendRightAxisHint=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
 
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){

--- a/src/models/ohlcBar.js
+++ b/src/models/ohlcBar.js
@@ -25,6 +25,8 @@ nv.models.ohlcBar = function() {
         , clipEdge = true
         , color = nv.utils.defaultColor()
         , interactive = false
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , xDomain
         , yDomain
         , xRange
@@ -82,6 +84,21 @@ nv.models.ohlcBar = function() {
             gEnter.append('g').attr('class', 'nv-ticks');
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+            var g_ohlc = wrapEnter.append('g').attr('class', 'nv-ohlc');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_ohlc
+                    .append("text")
+                    .attr('class', 'nv-ohlc-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             container
                 .on('click', function(d,i) {
@@ -206,6 +223,8 @@ nv.models.ohlcBar = function() {
         clipEdge: {get: function(){return clipEdge;}, set: function(_){clipEdge=_;}},
         id:       {get: function(){return id;}, set: function(_){id=_;}},
         interactive: {get: function(){return interactive;}, set: function(_){interactive=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
 
         x:     {get: function(){return getX;}, set: function(_){getX=_;}},
         y:     {get: function(){return getY;}, set: function(_){getY=_;}},

--- a/src/models/parallelCoordinates.js
+++ b/src/models/parallelCoordinates.js
@@ -25,6 +25,8 @@ nv.models.parallelCoordinates = function() {
         , dragging = []
         , axisWithUndefinedValues = []
         , lineTension = 1
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , foreground
         , background
         , dimensions
@@ -133,6 +135,21 @@ nv.models.parallelCoordinates = function() {
             gEnter.append('g').attr('class', 'nv-parallelCoordinates missingValuesline');
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+            var g_parallel = wrapEnter.append('g').attr('class', 'nv-parallel');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_parallel
+                    .append("text")
+                    .attr('class', 'nv-parallel-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-30)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             line.interpolate('cardinal').tension(lineTension);
             axis.orient('left');
@@ -443,6 +460,8 @@ nv.models.parallelCoordinates = function() {
         active: { get: function () { return active; }, set: function (_) { active = _; } },
         lineTension:   {get: function(){return lineTension;},     set: function(_){lineTension = _;}},
         undefinedValuesLabel : {get: function(){return undefinedValuesLabel;}, set: function(_){undefinedValuesLabel=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         
         // deprecated options
         dimensions: {get: function () { return dimensionData.map(function (d){return d.key}); }, set: function (_) {

--- a/src/models/pie.js
+++ b/src/models/pie.js
@@ -22,7 +22,7 @@ nv.models.pie = function() {
         , donut = false
         , title = false
         , growOnHover = true
-        , titleOffset = 0
+        , titleOffset = {top: 0, left: 0}
         , labelSunbeamLayout = false
         , startAngle = false
         , padAngle = false
@@ -136,7 +136,7 @@ nv.models.pie = function() {
             }
 
             // if title is specified and donut, put it in the middle
-            if (donut && title) {
+            if (donut & title) {
                 g_pie.append("text").attr('class', 'nv-pie-title');
 
                 wrap.select('.nv-pie-title')
@@ -146,9 +146,9 @@ nv.models.pie = function() {
                     })
                     .style("font-size", (Math.min(availableWidth, availableHeight)) * donutRatio * 2 / (title.length + 2) + "px")
                     .attr("dy", "0.35em") // trick to vertically center text
-                    .attr('transform', function(d, i) {
-                        return 'translate(0, '+ titleOffset + ')';
-                    });
+                    .attr('transform', function(d, i) { return 'translate(0,0)'; })
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
             }
 
             var slices = wrap.select('.nv-pie').selectAll('.nv-slice').data(pie);

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -37,7 +37,7 @@ nv.models.scatter = function() {
         , yRange       = null // Override y range
         , sizeDomain   = null // Override point size domain
         , title = false
-        , titleOffset = 0
+        , titleOffset = {top: 0, left: 0}
         , sizeRange    = null
         , singlePoint  = false
         , dispatch     = d3.dispatch('elementClick', 'elementDblClick', 'elementMouseover', 'elementMouseout', 'renderEnd')
@@ -563,8 +563,9 @@ nv.models.scatter = function() {
                     .style("text-anchor", "middle")
                     .style("font-size", "150%")
                     .text(function (d) { return title; })
-                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ', '+ titleOffset + ')'; }) // center title
-                    .attr('dy','-10px'); // nudge title up a bit
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
             }
 
 
@@ -688,8 +689,8 @@ nv.models.scatter = function() {
         pointRange:   {get: function(){return sizeRange;}, set: function(_){sizeRange=_;}},
         forceX:       {get: function(){return forceX;}, set: function(_){forceX=_;}},
         forceY:       {get: function(){return forceY;}, set: function(_){forceY=_;}},
-        title:      {get: function(){return title;}, set: function(_){title=_;}},
-        titleOffset:    {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         forcePoint:   {get: function(){return forceSize;}, set: function(_){forceSize=_;}},
         interactive:  {get: function(){return interactive;}, set: function(_){interactive=_;}},
         pointActive:  {get: function(){return pointActive;}, set: function(_){pointActive=_;}},

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -562,12 +562,9 @@ nv.models.scatter = function() {
                     .attr('class', 'nv-scatter-title')
                     .style("text-anchor", "middle")
                     .style("font-size", "150%")
-                    .text(function (d) {
-                        return title;
-                    })
-                    .attr('transform', function(d, i) {
-                        return 'translate(' + (availableWidth / 2) + ', '+ titleOffset + ')';
-                    });
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ', '+ titleOffset + ')'; }) // center title
+                    .attr('dy','-10px'); // nudge title up a bit
             }
 
 

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -216,7 +216,7 @@ nv.models.scatter = function() {
             var defsEnter = wrapEnter.append('defs');
             var gEnter = wrapEnter.append('g');
             var g = wrap.select('g');
-            var g_scatter = wrapEnter.append('g').attr('class', 'nv-scatter');
+            var g_scatter = gEnter.append('g').attr('class', 'nv-title');
 
             wrap.classed('nv-single-point', singlePoint);
             gEnter.append('g').attr('class', 'nv-groups');

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -36,6 +36,8 @@ nv.models.scatter = function() {
         , xRange       = null // Override x range
         , yRange       = null // Override y range
         , sizeDomain   = null // Override point size domain
+        , title = false
+        , titleOffset = 0
         , sizeRange    = null
         , singlePoint  = false
         , dispatch     = d3.dispatch('elementClick', 'elementDblClick', 'elementMouseover', 'elementMouseout', 'renderEnd')
@@ -210,10 +212,11 @@ nv.models.scatter = function() {
 
             // Setup containers and skeleton of chart
             var wrap = container.selectAll('g.nv-wrap.nv-scatter').data([data]);
-            var wrapEnter = wrap.enter().append('g').attr('class', 'nvd3 nv-wrap nv-scatter nv-chart-' + id);
+            var wrapEnter = wrap.enter().append('g').attr('class', 'nvd3 nv-wrap nv-scatter moo nv-chart-' + id);
             var defsEnter = wrapEnter.append('defs');
             var gEnter = wrapEnter.append('g');
             var g = wrap.select('g');
+            var g_scatter = wrapEnter.append('g').attr('class', 'nv-scatter');
 
             wrap.classed('nv-single-point', singlePoint);
             gEnter.append('g').attr('class', 'nv-groups');
@@ -552,6 +555,22 @@ nv.models.scatter = function() {
                 .size(function (d) { return z(getSize(d[0], d[1])) })
             );
 
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_scatter
+                    .append("text")
+                    .attr('class', 'nv-scatter-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) {
+                        return title;
+                    })
+                    .attr('transform', function(d, i) {
+                        return 'translate(' + (availableWidth / 2) + ', '+ titleOffset + ')';
+                    });
+            }
+
+
             // add label a label to scatter chart
             if(showLabels)
             {
@@ -672,6 +691,8 @@ nv.models.scatter = function() {
         pointRange:   {get: function(){return sizeRange;}, set: function(_){sizeRange=_;}},
         forceX:       {get: function(){return forceX;}, set: function(_){forceX=_;}},
         forceY:       {get: function(){return forceY;}, set: function(_){forceY=_;}},
+        title:      {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:    {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         forcePoint:   {get: function(){return forceSize;}, set: function(_){forceSize=_;}},
         interactive:  {get: function(){return interactive;}, set: function(_){interactive=_;}},
         pointActive:  {get: function(){return pointActive;}, set: function(_){pointActive=_;}},

--- a/src/models/sparkline.js
+++ b/src/models/sparkline.js
@@ -20,6 +20,8 @@ nv.models.sparkline = function() {
         , yDomain
         , xRange
         , yRange
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , showMinMaxPoints = true
         , showCurrentPoint = true
         , dispatch = d3.dispatch('renderEnd')
@@ -54,6 +56,21 @@ nv.models.sparkline = function() {
             var g = wrap.select('g');
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
+
+            var g_spark = wrapEnter.append('g').attr('class', 'nv-spark');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_spark
+                    .append("text")
+                    .attr('class', 'nv-spark-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
 
             var paths = wrap.selectAll('path')
                 .data(function(d) { return [d] });
@@ -119,6 +136,8 @@ nv.models.sparkline = function() {
         animate:          {get: function(){return animate;}, set: function(_){animate=_;}},
         showMinMaxPoints: {get: function(){return showMinMaxPoints;}, set: function(_){showMinMaxPoints=_;}},
         showCurrentPoint: {get: function(){return showCurrentPoint;}, set: function(_){showCurrentPoint=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
 
         //functor options
         x: {get: function(){return getX;}, set: function(_){getX=d3.functor(_);}},

--- a/src/models/stackedArea.js
+++ b/src/models/stackedArea.js
@@ -22,6 +22,8 @@ nv.models.stackedArea = function() {
         , clipEdge = false // if true, masks lines within x and y scale
         , x //can be accessed via chart.xScale()
         , y //can be accessed via chart.yScale()
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , scatter = nv.models.scatter()
         , duration = 250
         , dispatch =  d3.dispatch('areaClick', 'areaMouseover', 'areaMouseout','renderEnd', 'elementClick', 'elementMouseover', 'elementMouseout')
@@ -98,6 +100,22 @@ nv.models.stackedArea = function() {
 
             gEnter.append('g').attr('class', 'nv-areaWrap');
             gEnter.append('g').attr('class', 'nv-scatterWrap');
+
+            var g_stack = wrapEnter.append('g').attr('class', 'nv-stack');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_stack
+                    .append("text")
+                    .attr('class', 'nv-stack-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + (availableWidth / 2) + ',-10)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
+
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
             
@@ -277,6 +295,8 @@ nv.models.stackedArea = function() {
         offset:      {get: function(){return offset;}, set: function(_){offset=_;}},
         order:    {get: function(){return order;}, set: function(_){order=_;}},
         interpolate:    {get: function(){return interpolate;}, set: function(_){interpolate=_;}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
 
         // simple functor options
         x:     {get: function(){return getX;}, set: function(_){getX = d3.functor(_);}},

--- a/src/models/sunburst.js
+++ b/src/models/sunburst.js
@@ -235,6 +235,7 @@ nv.models.sunburst = function() {
                     .attr('class', 'nv-sunburst-title')
                     .style("text-anchor", "middle")
                     .style("font-size", "150%")
+                    .style('opacity',1)
                     .text(function (d) { return title; })
                     .attr('transform', function(d, i) { return 'translate(' + ((availableWidth / 2) + margin.left + margin.right) + ',30)'; }) // center title
                     .attr('dx',titleOffset.left)

--- a/src/models/sunburst.js
+++ b/src/models/sunburst.js
@@ -17,6 +17,8 @@ nv.models.sunburst = function() {
         , showLabels = false
         , labelFormat = function(d){if(mode === 'count'){return d.name + ' #' + d.value}else{return d.name + ' ' + (d.value || d.size)}}
         , labelThreshold = 0.02
+        , title = false
+        , titleOffset = {top: 0, left: 0}
         , sort = function(d1, d2){return d1.name > d2.name;}
         , key = function(d,i){
             if (d.parent !== undefined) {
@@ -224,6 +226,22 @@ nv.models.sunburst = function() {
                 wrap.attr('transform', 'translate(' + ((availableWidth / 2) + margin.left + margin.right) + ',' + ((availableHeight / 2) + margin.top + margin.bottom) + ')');
             }
 
+            var g_sunburst = container.append('g').attr('class', 'nv-sunburst');
+
+            // add a title if specified
+            if (title) {
+                var plotTitle = g_sunburst
+                    .append("text")
+                    .attr('class', 'nv-sunburst-title')
+                    .style("text-anchor", "middle")
+                    .style("font-size", "150%")
+                    .text(function (d) { return title; })
+                    .attr('transform', function(d, i) { return 'translate(' + ((availableWidth / 2) + margin.left + margin.right) + ',30)'; }) // center title
+                    .attr('dx',titleOffset.left)
+                    .attr('dy',titleOffset.top)
+            }
+
+
             container.on('click', function (d, i) {
                 dispatch.chartClick({
                     data: d,
@@ -374,6 +392,8 @@ nv.models.sunburst = function() {
         labelThreshold: {get: function(){return labelThreshold;}, set: function(_){labelThreshold=_}},
         sort: {get: function(){return sort;}, set: function(_){sort=_}},
         key: {get: function(){return key;}, set: function(_){key=_}},
+        title:        {get: function(){return title;}, set: function(_){title=_;}},
+        titleOffset:  {get: function(){return titleOffset;}, set: function(_){titleOffset=_;}},
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){
             margin.top    = _.top    != undefined ? _.top    : margin.top;


### PR DESCRIPTION
Inspired by #2035, I've added a `title()` and `titleOffset()` option for all of the chart types.

- `title` simply takes a string and adds it to the top of the chart with a font size of 150%
- `titleOffset` takes an object of the form `{top: 0, left: 0}` and allows the user to adjust the positioning of the title relative to the top/center of the chart.

Default values are
```javascript
title: false,
titleOffset: {top: 0, left: 0}
```
