### PR TITLE
Fixed point highlighting on line chart after zoom or pan

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -302,7 +302,7 @@ nv.models.lineChart = function() {
                         var point = currentValues[pointIndex];
                         var pointYValue = chart.y()(point, pointIndex);
                         if (pointYValue !== null) {
-                            lines.highlightPoint(i, pointIndex, true);
+                            lines.highlightPoint(i, series.values.indexOf(point), true);
                         }
                         if (point === undefined) return;
                         if (singlePoint === undefined) singlePoint = point;


### PR DESCRIPTION
This is a fix for #2024.  When zooming or panning to the right, if the leftmost visible point is not the first index, the wrong points are highlighted when the interactiveGuideline is enabled. As mentioned in that issue, this fix should not affect the case described in the comment, as it checks the indexes after that case is handled. This changes the passed index from the point's index of the filtered array to its index in the full series.  