### PR TITLE
Fixed scatter point highlighting persistence on zoom

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -239,10 +239,11 @@ nv.models.scatter = function() {
                 needsUpdate = false;
 
                 if (!interactive) return false;
-
+                container.selectAll(".nv-point.hover").classed("hover", false);
                 // inject series and point index for reference into voronoi
                 if (useVoronoi === true) {
 
+                	
                     // nuke all voronoi paths on reload and recreate them
                     wrap.select('.nv-point-paths').selectAll('path').remove();
 


### PR DESCRIPTION
This is a bugfix for zooming when the guideline is off. When hovering over a point, zooming in such that the mouse leaves the selection area of the point would not remove the point's highlighting. This resulted in the point being permanently highlighted:
 
![duplicated_circles](https://user-images.githubusercontent.com/13516182/27196472-8e7eaa8a-51d8-11e7-80db-2ef8d0ab3e0e.PNG)

This was fixed by clearing any highlighted points on mouse move, before it chooses a new one to highlight.
