### PR TITLE
Update (existing) label texts for scatter-plots

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -593,6 +593,8 @@ nv.models.scatter = function() {
                     .classed('hover',false);
                 });
                 titles.watchTransition(renderWatch, 'scatter labels')
+                    .text(function(d,i){ 
+                        return d[0].label;})
                     .attr('transform', function(d) {
                         var dx = nv.utils.NaNtoZero(x(getX(d[0],d[1])))+ Math.sqrt(z(getSize(d[0],d[1]))/Math.PI)+2;
                         return 'translate(' + dx + ',' + nv.utils.NaNtoZero(y(getY(d[0],d[1]))) + ')'


### PR DESCRIPTION
I probably have a specific use-case, but I am using a chart linked to a map, when the map is moved/zoomed I update the data of the chart and I noticed that the labels in my scatterChart were not updated accordingly. 

I noticed that the locations of the labels where changed correctly but the text-contents where completely random. I assumed this has to do with the fact that the default identifier is the location in the array. I added an `id` field to my data but this did not help at all. 

So I am a bit stumped why the id was not taken into account (it never is/was?), so the easy fix was also update the label's text contents on update. 

This is a pretty small change, do you need anything else to be able to merge this? 