### PR TITLE
Fix `atleastOnePoint not found` error.

### DIFF
--- a/build/nv.d3.js
+++ b/build/nv.d3.js
@@ -14781,7 +14781,7 @@ nv.models.stackedAreaChart = function() {
 
             interactiveLayer.dispatch.on('elementMousemove', function(e) {
                 stacked.clearHighlights();
-                var singlePoint, pointIndex, pointXLocation, allData = [], valueSum = 0, allNullValues = true;
+                var singlePoint, pointIndex, pointXLocation, allData = [], valueSum = 0, allNullValues = true, atleastOnePoint = false;
                 data
                     .filter(function(series, i) {
                         series.seriesIndex = i;
@@ -14793,8 +14793,9 @@ nv.models.stackedAreaChart = function() {
                         var pointYValue = chart.y()(point, pointIndex);
                         if (pointYValue != null && pointYValue > 0) {
                             stacked.highlightPoint(i, pointIndex, true);
+                            atleastOnePoint = true;
                         }
-                    
+
                         // Draw at least one point if all values are zero.
                         if (i === (data.length - 1) && !atleastOnePoint) {
                             stacked.highlightPoint(i, pointIndex, true);


### PR DESCRIPTION
The built js file is not up-to-date. The variable `atleastOnePoint` is not defined but used. The fix merges the latest [stackedAreaChart.js](https://github.com/novus/nvd3/blob/master/src/models/stackedAreaChart.js#L405) into [nv.d3.js](https://github.com/novus/nvd3/blob/master/build/nv.d3.js#L14799).

Stacked area chart then works fine with this fix.