### PR TITLE
axis.orient('top') label spacing fix

### DIFF
--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -78,6 +78,7 @@ nv.models.axis = function() {
             var w;
             switch (axis.orient()) {
                 case 'top':
+                    xLabelMargin = axisLabelDistance + 36;
                     axisLabel.enter().append('text').attr('class', 'nv-axislabel');
                   w = 0;
                   if (scale.range().length === 1) {
@@ -89,7 +90,7 @@ nv.models.axis = function() {
                   };
                     axisLabel
                         .attr('text-anchor', 'middle')
-                        .attr('y', 0)
+                        .attr('y', -xLabelMargin)
                         .attr('x', w/2);
                     if (showMaxMin) {
                         axisMaxMin = wrap.selectAll('g.nv-axisMaxMin')


### PR DESCRIPTION
No consideration was given to positioning the axis label in the `top` orientation - this fixes that by using the same label positioning as `bottom`, but in the negative direction.