### PR TITLE
allow x/y distribution to update on chart option change

### DIFF
--- a/examples/scatterChart.html
+++ b/examples/scatterChart.html
@@ -5,6 +5,7 @@
     <link href="../build/nv.d3.css" rel="stylesheet" type="text/css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js" charset="utf-8"></script>
     <script src="../build/nv.d3.js"></script>
+    <script src="../src/models/scatterChart.js"></script>
 
     <style>
         text {
@@ -40,14 +41,15 @@
     });
 
     // create the chart
-    var chart;
+    chart = null;
     nv.addGraph(function() {
         chart = nv.models.scatterChart()
-            .showDistX(true)
+            .showDistX(false)
             .showDistY(true)
             .useVoronoi(true)
             .color(d3.scale.category10().range())
             .duration(300)
+			//.showLabels(true)
         ;
         chart.dispatch.on('renderEnd', function(){
             console.log('render complete');

--- a/examples/scatterChart.html
+++ b/examples/scatterChart.html
@@ -5,7 +5,6 @@
     <link href="../build/nv.d3.css" rel="stylesheet" type="text/css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js" charset="utf-8"></script>
     <script src="../build/nv.d3.js"></script>
-    <script src="../src/models/scatterChart.js"></script>
 
     <style>
         text {
@@ -41,15 +40,14 @@
     });
 
     // create the chart
-    chart = null;
+    var chart;
     nv.addGraph(function() {
         chart = nv.models.scatterChart()
-            .showDistX(false)
+            .showDistX(true)
             .showDistY(true)
             .useVoronoi(true)
             .color(d3.scale.category10().range())
             .duration(300)
-			//.showLabels(true)
         ;
         chart.dispatch.on('renderEnd', function(){
             console.log('render complete');

--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -254,37 +254,40 @@ nv.models.scatterChart = function() {
             }
 
             // Setup Distribution
-            if (showDistX) {
-                distX
-                    .getData(scatter.x())
-                    .scale(x)
-                    .width(availableWidth)
-                    .color(data.map(function(d,i) {
-                        return d.color || color(d, i);
-                    }).filter(function(d,i) { return !data[i].disabled }));
-                gEnter.select('.nv-distWrap').append('g')
-                    .attr('class', 'nv-distributionX');
-                g.select('.nv-distributionX')
-                    .attr('transform', 'translate(0,' + y.range()[0] + ')')
-                    .datum(data.filter(function(d) { return !d.disabled }))
-                    .call(distX);
-            }
+            distX
+                .getData(scatter.x())
+                .scale(x)
+                .width(availableWidth)
+                .color(data.map(function(d,i) {
+                    return d.color || color(d, i);
+                }).filter(function(d,i) { return !data[i].disabled }));
+            gEnter.select('.nv-distWrap').append('g')
+                .attr('class', 'nv-distributionX');
+            g.select('.nv-distributionX')
+                .attr('transform', 'translate(0,' + y.range()[0] + ')')
+                .datum(data.filter(function(d) { return !d.disabled }))
+                .call(distX)
+                .style('opacity', function() { return showDistX ? '1' : '1e-6'; })
+                .watchTransition(renderWatch, 'scatterPlusLineChart')
+                .style('opacity', function() { return showDistX ? '1' : '1e-6'; })
 
-            if (showDistY) {
-                distY
-                    .getData(scatter.y())
-                    .scale(y)
-                    .width(availableHeight)
-                    .color(data.map(function(d,i) {
-                        return d.color || color(d, i);
-                    }).filter(function(d,i) { return !data[i].disabled }));
-                gEnter.select('.nv-distWrap').append('g')
-                    .attr('class', 'nv-distributionY');
-                g.select('.nv-distributionY')
-                    .attr('transform', 'translate(' + (rightAlignYAxis ? availableWidth : -distY.size() ) + ',0)')
-                    .datum(data.filter(function(d) { return !d.disabled }))
-                    .call(distY);
-            }
+
+            distY
+                .getData(scatter.y())
+                .scale(y)
+                .width(availableHeight)
+                .color(data.map(function(d,i) {
+                    return d.color || color(d, i);
+                }).filter(function(d,i) { return !data[i].disabled }));
+            gEnter.select('.nv-distWrap').append('g')
+                .attr('class', 'nv-distributionY');
+            g.select('.nv-distributionY')
+                .attr('transform', 'translate(' + (rightAlignYAxis ? availableWidth : -distY.size() ) + ',0)')
+                .datum(data.filter(function(d) { return !d.disabled }))
+                .call(distY)
+                .style('opacity', function() { return showDistY ? '1' : '1e-6'; })
+                .watchTransition(renderWatch, 'scatterPlusLineChart')
+                .style('opacity', function() { return showDistY ? '1' : '1e-6'; })
 
             //============================================================
             // Event Handling/Dispatching (in chart's scope)


### PR DESCRIPTION
current `scatterChart.js` does not allow for updating the `showDistX()` & `showDistY()` options after a chart has been drawn; this PR always generates the DOM elements for the axis distributions and does a `watchTransition()` on them to properly set the opacity.