### PR TITLE
Fix legendPosition bottom on stackedAreaChart

### DIFF
--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -173,8 +173,7 @@ nv.models.stackedAreaChart = function() {
                 g.select('.nv-legendWrap').datum(data).call(legend);
 
                 if (legendPosition === 'bottom') {
-                	// constant from axis.js, plus some margin for better layout
-                	var xAxisHeight = (showXAxis ? 12 : 0) + 10;
+                	var xAxisHeight = xAxis.height();
                    	margin.bottom = Math.max(legend.height() + xAxisHeight, margin.bottom);
                    	availableHeight = nv.utils.availableHeight(height, container, margin) - (focusEnable ? focus.height() : 0);
                 	var legendTop = availableHeight + xAxisHeight;


### PR DESCRIPTION
Bottom legend on stackedAreaChart doesn't accommodate for full X axis vertical spacing and overlaps legend with label.

This PR fixes it in a manner that is consistent with the other chart types that support bottom legend (lineChart, multiBarChart, multiBarHorizontalChart).

Before:
<img width="572" alt="before" src="https://user-images.githubusercontent.com/6784226/32634820-6c33f0ae-c562-11e7-88f3-2d5e5e8a033c.png">

After:
<img width="567" alt="after" src="https://user-images.githubusercontent.com/6784226/32634830-713f1470-c562-11e7-8ae3-a1f09495cedf.png">
