### PR TITLE
Fix points position update on line chart

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -163,7 +163,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-karma');
     grunt.loadNpmTasks('grunt-text-replace');
 
-    grunt.registerTask('default', ['concat', 'copy', 'postcss', 'karma:unit']);
+    grunt.registerTask('default', ['concat', 'copy', 'postcss']);
     grunt.registerTask('production', ['concat', 'uglify', 'copy', 'postcss', 'cssmin', 'replace']);
     grunt.registerTask('release', ['production']);
     grunt.registerTask('lint', ['jshint']);

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -163,7 +163,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-karma');
     grunt.loadNpmTasks('grunt-text-replace');
 
-    grunt.registerTask('default', ['concat', 'copy', 'postcss']);
+    grunt.registerTask('default', ['concat', 'copy', 'postcss', 'karma:unit']);
     grunt.registerTask('production', ['concat', 'uglify', 'copy', 'postcss', 'cssmin', 'replace']);
     grunt.registerTask('release', ['production']);
     grunt.registerTask('lint', ['jshint']);

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -253,7 +253,7 @@ nv.models.lineChart = function() {
             // Update Focus
             //============================================================
             if (!focusEnable && focus.brush.extent() === null) {
-                linesWrap.call(lines);
+                linesWrap.transition().call(lines);
                 updateXAxis();
                 updateYAxis();
             } else {


### PR DESCRIPTION
Fixes #2018.

Issue is that the scatter layer is watching a transition to synchronize point updates (`transform` attribute) [here](https://github.com/novus/nvd3/blob/master/src/models/scatter.js#L537).

But the `lineChart` (the parent container) is not initiating the call via a `transition` (like the [scatterChart](https://github.com/novus/nvd3/blob/master/src/models/scatterChart.js#L101) and other charts), therefore the point transform attributes aren't updated.

This PR fixes that and makes the `lineChart` behavior consistent with the other charts.
