### PR TITLE
Update multiChart.js

### DIFF
--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -215,9 +215,6 @@ nv.models.multiChart = function() {
                         return a.map(function(aVal,i){return {x: aVal.x, y: aVal.y + b[i].y}})
                     });
             }
-            if (dataBars1.length) {
-                extraValue1BarStacked.push({x:0, y:0});
-            }
 
             var extraValue2BarStacked = [];
             if (bars2.stacked() && dataBars2.length) {
@@ -227,10 +224,6 @@ nv.models.multiChart = function() {
                     extraValue2BarStacked = extraValue2BarStacked.reduce(function(a,b){
                         return a.map(function(aVal,i){return {x: aVal.x, y: aVal.y + b[i].y}})
                     });
-            }
-
-            if (dataBars2.length) {
-              extraValue2BarStacked.push({x:0, y:0});
             }
 
             function getStackedAreaYs(series) {


### PR DESCRIPTION
218 to 220 Removing these lines as this is offsetting the count of records in 2 bar type data collections.
232 to 234 Removing these lines as this is offsetting the count of records in 2 bar type data collections.
to replicate the issue I have created a [plunker](https://plnkr.co/plunks/3hT7EIJkP2B8OitS). (just toggle in the index.html the reference to nv.d3.min.js to the local copy of nv.d3.js) and then in the chart first unselect the 'another' data series and select again you will get an error in console with the nv.d3.min.js, which is not there in the modified nv.d3.js)