### PR TITLE
fixed tooltip position for charts placed on lower part of the page

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -221,7 +221,7 @@ nv.models.tooltip = function() {
             var pos = position(),
                 gravityOffset = calcGravityOffset(pos),
                 left = pos.left + gravityOffset.left,
-                top = pos.top + gravityOffset.top;
+                top = pos.top + gravityOffset.top + window.scrollY;
 
             // delay hiding a bit to avoid flickering
             if (hidden) {


### PR DESCRIPTION
as per issue #2163, fixed by @RedScourge. This will fix the tooltip position of charts placed on lower part of the page where scrolling is needed.