### PR TITLE
Fix points highlights in multichart with disabled series

### DIFF
--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -463,7 +463,10 @@ nv.models.multiChart = function() {
               };
 
               var relevantChart = chartMap[series.type]['yAxis' + series.yAxis].chart;
-              var relevantDatasets = chartMap[series.type]['yAxis' + series.yAxis].data;
+              var relevantDatasets = chartMap[series.type]['yAxis' + series.yAxis].data.filter(function(series) {
+                return(!series.disabled);
+              });
+
               var seriesIndex = relevantDatasets.reduce(function (seriesIndex, dataSet, i) {
                 return dataSet.key === series.key ? i : seriesIndex;
               }, 0);


### PR DESCRIPTION
To reproduce, in a multiChart disable an intermediate data series (not the first/last one) by clicking on the series circle and hover the mouse in the chart.