### PR TITLE
Fix graphic artifacts in stacked area when interpolation is used

### DIFF
--- a/src/models/stackedArea.js
+++ b/src/models/stackedArea.js
@@ -144,7 +144,8 @@ nv.models.stackedArea = function() {
                 .defined(defined)
                 .x(function(d,i)  { return x(getX(d,i)) })
                 .y0(function(d) { return y(d.display.y0) })
-                .y1(function(d) { return y(d.display.y0) });
+                .y1(function(d) { return y(d.display.y0) })
+                .interpolate(interpolate);
 
             var path = g.select('.nv-areaWrap').selectAll('path.nv-area')
                 .data(function(d) { return d });


### PR DESCRIPTION
Here is the bug with interpolate set to "monotone":

![area_interpolate_bug](https://user-images.githubusercontent.com/5488003/43523896-0f9489be-959e-11e8-8515-687b656b793e.gif)
