### PR TITLE
ci: remove Git markers to fix testfile

### DIFF
--- a/test/mocha/differenceChart.js
+++ b/test/mocha/differenceChart.js
@@ -217,7 +217,7 @@
       describe('Processing Data', function () {
         it('should does not process data if series toggled off', function () {
           builder.model.showPredictedLine(false);
-<<<<<<< HEAD
+
           var expectedData = [{
             key: 'Predicted Data minus Actual Data (Predicted > Actual)',
             type: 'area',
@@ -245,7 +245,7 @@
             processed: true,
             strokeWidth: 1
           }];
-=======
+
           var expectedData = [
             {
               key: 'Predicted Data minus Actual Data (Predicted > Actual)',


### PR DESCRIPTION
It seems there was a merge conflict or something else in the past and the markers were left which breaks the unit tests (CI is red, this should be always checked).