### PR TITLE
ci: use Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "0.12"
+    - "10"
 before_install:
     - "npm install -g bower"
     - "npm install -g grunt-cli"


### PR DESCRIPTION
Node.js 0.12 is very old and has reached its EOL. We should use Node.js 10 for running the tests (the latest LTS branch).