### PR TITLE
docs: Fix simple typo, violing -> violin

### DIFF
--- a/build/nv.d3.js
+++ b/build/nv.d3.js
@@ -5019,7 +5019,7 @@ nv.models.distroPlot = function() {
      * of the violin.
      *
      * @param (list) kde - x & y kde cooridinates
-     * @param (list) extent - min/max y-values used for clamping violing
+     * @param (list) extent - min/max y-values used for clamping violin
      */
     function clampViolinKDE(kde, extent) {
 

--- a/src/models/distroPlot.js
+++ b/src/models/distroPlot.js
@@ -341,7 +341,7 @@ nv.models.distroPlot = function() {
      * of the violin.
      *
      * @param (list) kde - x & y kde cooridinates
-     * @param (list) extent - min/max y-values used for clamping violing
+     * @param (list) extent - min/max y-values used for clamping violin
      */
     function clampViolinKDE(kde, extent) {
 


### PR DESCRIPTION
There is a small typo in build/nv.d3.js, src/models/distroPlot.js.

Should read `violin` rather than `violing`.

