### PR TITLE
Fixes the overlapping legend of `cumulativeLineChart`

### DIFF
--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -204,7 +204,7 @@ nv.models.cumulativeLineChart = function() {
             if (!showLegend) {
                 g.select('.nv-legendWrap').selectAll('*').remove();
             } else {
-                legend.width(availableWidth);
+                legend.width(availableWidth - 140);
 
                 g.select('.nv-legendWrap')
                     .datum(data)
@@ -216,7 +216,7 @@ nv.models.cumulativeLineChart = function() {
                 }
 
                 g.select('.nv-legendWrap')
-                    .attr('transform', 'translate(0,' + (-margin.top) +')')
+                    .attr('transform', 'translate(140,' + (-margin.top) +')');
             }
 
             // Controls


### PR DESCRIPTION
The purpose of this PR is to fix the legend overlapping the controls on the `cumulativeLineChart`. This happens depending on the width of the chart - the solution is replicating the behaviour of the `multiBarChart`

## Before

<img width="890" alt="Capture d’écran, le 2023-09-15 à 16 34 50" src="https://github.com/novus/nvd3/assets/1114325/ff9aba31-cda0-488e-81df-374a28fdbea3">


## After

<img width="886" alt="Capture d’écran, le 2023-09-15 à 16 30 08" src="https://github.com/novus/nvd3/assets/1114325/1444b5cd-734f-4754-a451-a0bd196073e2">
